### PR TITLE
chore: Update GH Action workflows

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,31 +1,31 @@
 name: Build and Push
 
 on:
-  pull_request:
-    branches: [ main ]
-    types: [closed]
+  push:
+    branches: [main]
 
 jobs:
-  build:
-    if: github.event.pull_request.merged == true
+  test:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Build runtime image
-      run: |
-        BUILD_ID=$(date '+%Y%m%d')-$(git rev-parse HEAD | cut -c -5)
-        IMAGE_TAG=main_${BUILD_ID}
-
-        ./scripts/build_docker.sh --target runtime --tag $IMAGE_TAG
-
-    - name: Log in to docker hub
-      run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
-
-    - name: Push to docker hub
-      run: |
-        IMAGE_NAME=modelmesh-runtime-adapter
-        IMAGE_ID=kserve/$IMAGE_NAME
-        IMAGE_VERSION=latest
-
-        docker push $IMAGE_ID:$IMAGE_VERSION
+      - uses: actions/checkout@v2
+      - name: Build develop image
+        run: make build.develop
+      - name: Run lint
+        run: ./scripts/develop.sh make fmt
+      - name: Run unit test
+        run: ./scripts/develop.sh make test
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: kserve/modelmesh-runtime-adapter
+      IMAGE_TAG: latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build runtime image
+        run: make build
+      - name: Log in to Docker Hub
+        run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_ACCESS_TOKEN }}
+      - name: Push to Docker Hub
+        run: docker push ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,23 +1,17 @@
 name: Unit Test
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]        
+    branches: [main]
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Build develop image
-      run: |
-        BUILD_ID=$(date '+%Y%m%d')-$(git rev-parse HEAD | cut -c -5)
-        IMAGE_TAG=main_${BUILD_ID}
-        ./scripts/build_docker.sh --target develop --tag $IMAGE_TAG
-    - name: Run unit test
-      run: |
-        ./scripts/develop.sh make test
+      - uses: actions/checkout@v2
+      - name: Build develop image
+        run: make build.develop
+      - name: Run lint
+        run: ./scripts/develop.sh make fmt
+      - name: Run unit test
+        run: ./scripts/develop.sh make test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,9 @@ information on using pull requests.
 
 The following should be viewed as Best Practices unless you know better ones (please submit a guidelines PR).
 
-| Practice | Rationale |
-| -------- | --------- |
-| Keep the code clean | The health of the codebase is imperative to the success of the project. Files should be under 500 lines long in most cases, which may mean a refactor is necessary before adding changes. |
-| Limit your scope | No one wants to review a 1000 line PR. Try to keep your changes focused to ease reviewability. This may mean separating a large feature into several smaller milestones.  |
-| Refine commit messages | Your commit messages should be in the imperative tense and clearly describe your feature upon first glance. See [this article](https://chris.beams.io/posts/git-commit/) for guidelines.
-| Reference an issue | Issues are a great way to gather design feedback from the community. To save yourself time on a controversial PR, first cut an issue for any major feature work. |
+| Practice               | Rationale                                                                                                                                                                                 |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Keep the code clean    | The health of the codebase is imperative to the success of the project. Files should be under 500 lines long in most cases, which may mean a refactor is necessary before adding changes. |
+| Limit your scope       | No one wants to review a 1000 line PR. Try to keep your changes focused to ease reviewability. This may mean separating a large feature into several smaller milestones.                  |
+| Refine commit messages | Your commit messages should be in the imperative tense and clearly describe your feature upon first glance. See [this article](https://chris.beams.io/posts/git-commit/) for guidelines.  |
+| Reference an issue     | Issues are a great way to gather design feedback from the community. To save yourself time on a controversial PR, first cut an issue for any major feature work.                          |

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -73,13 +73,10 @@ if [ "${DOCKER_TARGET}" != "runtime" ]; then
   IMAGE_SUFFIX="-${DOCKER_TARGET}"
 fi
 
-BASE_TAG="$(cat BASE_IMAGE_TAG | awk -F= '{print $2}')"
-
 declare -a docker_args=(
   --target "${DOCKER_TARGET}"
   -t "kserve/modelmesh-runtime-adapter${IMAGE_SUFFIX}:${DOCKER_TAG}"
   -t "kserve/modelmesh-runtime-adapter${IMAGE_SUFFIX}:latest"
-  --build-arg "BASE_IMAGE_TAG=${BASE_TAG}"
 )
 
 if [[ $DOCKER_TARGET == 'runtime' ]]; then


### PR DESCRIPTION
Updated the GitHub Action workflows that will now lint and test for PRs, and also, on a git push, lint+test, then build/push the new image to Docker Hub.

Misc fixes + Linting fixes are also included to pass the lint check.