### PR TITLE
chore: Add GitHub Action release tag workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -3,6 +3,8 @@ name: Build and Push
 on:
   push:
     branches: [main]
+    tags:
+      - v*
 
 jobs:
   test:
@@ -20,7 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: kserve/modelmesh-runtime-adapter
-      IMAGE_TAG: latest
     steps:
       - uses: actions/checkout@v2
       - name: Build runtime image
@@ -28,4 +29,13 @@ jobs:
       - name: Log in to Docker Hub
         run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_ACCESS_TOKEN }}
       - name: Push to Docker Hub
-        run: docker push ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+        run: |
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          echo $VERSION
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+
+          docker tag ${{ env.IMAGE_NAME }}:latest ${{ env.IMAGE_NAME }}:$VERSION
+          docker push ${{ env.IMAGE_NAME }}:$VERSION


### PR DESCRIPTION
#### Motivation

#### Modifications

#### Motivation

We want version tagged docker images to be pushed to DockerHub when a new release is tagged in GitHub.

#### Modifications

Adjusted the workflow file to also test, build, and push the image on tags.

#### Result

Tagged image versions on DockerHub.