### PR TITLE
feat(puller): support new storage spec semantics and refactor tests

### DIFF
--- a/model-serving-puller/puller/dotpath.go
+++ b/model-serving-puller/puller/dotpath.go
@@ -51,8 +51,7 @@ func set(params map[string]interface{}, dotpath string, value string) error {
 		return nil
 	}
 
-	var obj interface{}
-	obj = params
+	var obj interface{} = params
 	pathSoFar := fields[0]
 	for i, field := range fields {
 		var m map[string]interface{}
@@ -68,8 +67,8 @@ func set(params map[string]interface{}, dotpath string, value string) error {
 				m[field] = value
 
 			} else if obj, ok = m[field]; !ok {
-				m[field] = map[string]interface{}{}
-				obj = m[field]
+				obj = map[string]interface{}{}
+				m[field] = obj
 			}
 		} else {
 			return fmt.Errorf("expected a map at '%s'", pathSoFar)

--- a/model-serving-puller/puller/dotpath.go
+++ b/model-serving-puller/puller/dotpath.go
@@ -1,0 +1,80 @@
+// Copyright 2021 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package puller
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// Implements a simple "dotpath" style for setting values within JSON compatible configuration structs
+//
+// To keep things simple:
+// - only string values are supported
+// - paths can only trace object keys (not arrays)
+// - only values that are strings can be overwritten
+func ApplyParameterOverrides(params map[string]interface{}, overrides map[string]string) error {
+	for dotpath, value := range overrides {
+		if err := set(params, dotpath, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var splitRegex = regexp.MustCompile(`\.`)
+
+// Separate path into segments (split on `.`)
+func fieldsFromDotpath(dotpath string) []string {
+	return splitRegex.Split(dotpath, -1)
+}
+
+func set(params map[string]interface{}, dotpath string, value string) error {
+
+	if params == nil {
+		return fmt.Errorf("got nil map, unable to set value")
+	}
+
+	fields := fieldsFromDotpath(dotpath)
+	if len(fields) == 0 {
+		return nil
+	}
+
+	var obj interface{}
+	obj = params
+	pathSoFar := fields[0]
+	for i, field := range fields {
+		var m map[string]interface{}
+		var ok bool
+		if m, ok = obj.(map[string]interface{}); ok {
+			if i == len(fields)-1 {
+				// return an error if overwriting an existing value that is not a string
+				if _, ok = m[field]; ok {
+					if _, ok = m[field].(string); !ok {
+						return fmt.Errorf("expected a string at path '%s', but got %v", pathSoFar, m[field])
+					}
+				}
+				m[field] = value
+
+			} else if obj, ok = m[field]; !ok {
+				m[field] = map[string]interface{}{}
+				obj = m[field]
+			}
+		} else {
+			return fmt.Errorf("expected a map at '%s'", pathSoFar)
+		}
+		pathSoFar = fmt.Sprintf("%s.%s", pathSoFar, field)
+	}
+	return nil
+}

--- a/model-serving-puller/puller/dotpath.go
+++ b/model-serving-puller/puller/dotpath.go
@@ -15,7 +15,7 @@ package puller
 
 import (
 	"fmt"
-	"regexp"
+	"strings"
 )
 
 // Implements a simple "dotpath" style for setting values within JSON compatible configuration structs
@@ -33,15 +33,11 @@ func ApplyParameterOverrides(params map[string]interface{}, overrides map[string
 	return nil
 }
 
-var splitRegex = regexp.MustCompile(`\.`)
-
-// Separate path into segments (split on `.`)
 func fieldsFromDotpath(dotpath string) []string {
-	return splitRegex.Split(dotpath, -1)
+	return strings.Split(dotpath, ".")
 }
 
 func set(params map[string]interface{}, dotpath string, value string) error {
-
 	if params == nil {
 		return fmt.Errorf("got nil map, unable to set value")
 	}

--- a/model-serving-puller/puller/dotpath_test.go
+++ b/model-serving-puller/puller/dotpath_test.go
@@ -1,0 +1,95 @@
+// Copyright 2021 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package puller
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Dotpath(t *testing.T) {
+	tests := map[string]struct {
+		input     string            // JSON string representing the input map
+		overrides map[string]string // field overrides in a map of dotpaths to values
+		want      string            // JSON string representing the output map
+	}{
+		"change_key_value": {
+			input:     `{"key": "value", "another_key": "another value"}`,
+			overrides: map[string]string{"key": "simple"},
+			want:      `{"key": "simple", "another_key": "another value"}`,
+		},
+		"create_value": {
+			input:     `{}`,
+			overrides: map[string]string{"key": "create_me"},
+			want:      `{"key": "create_me"}`,
+		},
+		"create_nested_object": {
+			input: `{"key": "value"}`,
+			overrides: map[string]string{
+				"nested.object.key":     "nested value",
+				"nested.object.another": "another one",
+			},
+			want: `{"key": "value", "nested":{"object":{"key": "nested value", "another": "another one"}}}`,
+		},
+		"create_value_in_nested_object": {
+			input: `{"struct": {"param": "param_value"}}`,
+			overrides: map[string]string{
+				"struct.key": "create_me",
+			},
+			want: `{"struct": {"key": "create_me", "param": "param_value"}}`,
+		},
+		"error_no_overwrite_object": {
+			input: `{"struct": {"key": "value"}}`,
+			overrides: map[string]string{
+				"struct": "new_value",
+			},
+		},
+		"error_overwrite_array": {
+			input: `{"array": ["key"], "some_other_key": "value"}`,
+			overrides: map[string]string{
+				"array.key": "value",
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var obj map[string]interface{}
+			err := json.Unmarshal([]byte(tt.input), &obj)
+			assert.NoError(t, err)
+
+			err = ApplyParameterOverrides(obj, tt.overrides)
+			// let an empty value for `want` signal that an error is expected
+			if tt.want == "" {
+				assert.Error(t, err)
+				return
+			}
+
+			// compare results as JSON strings
+			got, err := json.Marshal(obj)
+			assert.NoError(t, err)
+
+			// re-serialize `want` to remove dependence on key order
+			var wobj map[string]interface{}
+			err = json.Unmarshal([]byte(tt.want), &wobj)
+			assert.NoError(t, err)
+			want, err := json.Marshal(wobj)
+			assert.NoError(t, err)
+
+			assert.Equal(t, string(want), string(got))
+		})
+	}
+}

--- a/model-serving-puller/puller/dotpath_test.go
+++ b/model-serving-puller/puller/dotpath_test.go
@@ -26,12 +26,12 @@ func Test_Dotpath(t *testing.T) {
 		overrides map[string]string // field overrides in a map of dotpaths to values
 		want      string            // JSON string representing the output map
 	}{
-		"change_key_value": {
+		"change_value": {
 			input:     `{"key": "value", "another_key": "another value"}`,
 			overrides: map[string]string{"key": "simple"},
 			want:      `{"key": "simple", "another_key": "another value"}`,
 		},
-		"create_value": {
+		"create_field": {
 			input:     `{}`,
 			overrides: map[string]string{"key": "create_me"},
 			want:      `{"key": "create_me"}`,
@@ -44,7 +44,7 @@ func Test_Dotpath(t *testing.T) {
 			},
 			want: `{"key": "value", "nested":{"object":{"key": "nested value", "another": "another one"}}}`,
 		},
-		"create_value_in_nested_object": {
+		"create_field_in_nested_object": {
 			input: `{"struct": {"param": "param_value"}}`,
 			overrides: map[string]string{
 				"struct.key": "create_me",
@@ -57,7 +57,7 @@ func Test_Dotpath(t *testing.T) {
 				"struct": "new_value",
 			},
 		},
-		"error_overwrite_array": {
+		"error_no_overwrite_array": {
 			input: `{"array": ["key"], "some_other_key": "value"}`,
 			overrides: map[string]string{
 				"array.key": "value",

--- a/model-serving-puller/puller/puller.go
+++ b/model-serving-puller/puller/puller.go
@@ -130,7 +130,6 @@ func (s *Puller) ProcessLoadModelRequest(req *mmesh.LoadModelRequest) (*mmesh.Lo
 	// if we still don't know the storage type, we cannot download the model, so return an error
 	storageType, ok := storageConfig[parameterKeyType].(string)
 	if !ok {
-		// return nil, fmt.Errorf("Unable to determine storage type. Either StorageKey must be set or StorageParameters must contain the 'type' parameter")
 		return nil, fmt.Errorf("Predictor Storage field missing")
 	}
 

--- a/model-serving-puller/puller/puller.go
+++ b/model-serving-puller/puller/puller.go
@@ -102,15 +102,13 @@ func (s *Puller) ProcessLoadModelRequest(req *mmesh.LoadModelRequest) (*mmesh.Lo
 		defaultStorageKey := fmt.Sprintf("_%s_serviceaccount_secrets", storageType)
 
 		var err error
-		storageConfig, err = s.PullerConfig.GetStorageConfiguration(defaultStorageKey, s.Log)
-		if err != nil {
+		if storageConfig, err = s.PullerConfig.GetStorageConfiguration(defaultStorageKey, s.Log); err != nil {
 			// do not error here, try to load from the parameters only
 			storageConfig = map[string]interface{}{}
 		}
 	} else {
 		var err error
-		storageConfig, err = s.PullerConfig.GetStorageConfiguration(*modelKey.StorageKey, s.Log)
-		if err != nil {
+		if storageConfig, err = s.PullerConfig.GetStorageConfiguration(*modelKey.StorageKey, s.Log); err != nil {
 			// if key was specified, but we could not find it, that is an error
 			return nil, fmt.Errorf("Did not find storage config for key %s: %w", *modelKey.StorageKey, err)
 		}
@@ -118,6 +116,7 @@ func (s *Puller) ProcessLoadModelRequest(req *mmesh.LoadModelRequest) (*mmesh.Lo
 
 	// DEPRECATED: allow top-level bucket key for backwards compatibility
 	if modelKey.Bucket != "" {
+		s.Log.Info(`Warning: use of ModelKey["bucket"] is deprecated, use ModelKey["storage_params"] instead`)
 		storageConfig["bucket"] = modelKey.Bucket
 	}
 
@@ -126,7 +125,6 @@ func (s *Puller) ProcessLoadModelRequest(req *mmesh.LoadModelRequest) (*mmesh.Lo
 		return nil, fmt.Errorf("Unable to merge storage parameters from the storage config and the Predictor Storage field: %w", err)
 	}
 
-	var storageType string
 	// if we still don't know the storage type, we cannot download the model, so return an error
 	storageType, ok := storageConfig[parameterKeyType].(string)
 	if !ok {

--- a/model-serving-puller/puller/puller.go
+++ b/model-serving-puller/puller/puller.go
@@ -30,11 +30,16 @@ import (
 	_ "github.com/kserve/modelmesh-runtime-adapter/pullman/storageproviders/s3"
 )
 
-const jsonAttrModelKeyStorageKey = "storage_key"
-const jsonAttrModelKeyBucket = "bucket"
-const jsonAttrModelKeyDiskSizeBytes = "disk_size_bytes"
-const jsonAttrModelSchemaPath = "schema_path"
-const jsonAttrStorageParams = "storage_params"
+const parameterKeyType = "type"
+
+// JSON passed in ModelInfo.Key field of registration requests
+type ModelKeyInfo struct {
+	Bucket        string            `json:"bucket,omitempty"`
+	DiskSizeBytes int64             `json:"disk_size_bytes"`
+	SchemaPath    *string           `json:"schema_path,omitempty"`
+	StorageKey    *string           `json:"storage_key,omitempty"`
+	StorageParams map[string]string `json:"storage_params,omitempty"`
+}
 
 // Puller represents the GRPC server and its configuration
 type Puller struct {
@@ -79,45 +84,54 @@ func NewPullerFromConfig(log logr.Logger, config *PullerConfiguration) *Puller {
 // - rewrite ModelKey["schema_path"] to a local filesystem path
 // - add the size of the model on disk to ModelKey["disk_size_bytes"]
 func (s *Puller) ProcessLoadModelRequest(req *mmesh.LoadModelRequest) (*mmesh.LoadModelRequest, error) {
-	var modelKey map[string]interface{}
+	var modelKey ModelKeyInfo
 	if parseErr := json.Unmarshal([]byte(req.ModelKey), &modelKey); parseErr != nil {
-		return nil, fmt.Errorf("Invalid modelKey in LoadModelRequest. ModelKey value '%s' is not valid JSON: %s", req.ModelKey, parseErr)
+		return nil, fmt.Errorf("Invalid modelKey in LoadModelRequest. Error processing JSON '%s': %s", req.ModelKey, parseErr)
 	}
-	schemaPath, ok := modelKey[jsonAttrModelSchemaPath].(string)
-	if !ok {
-		if modelKey[jsonAttrModelSchemaPath] != nil {
-			return nil, fmt.Errorf("Invalid schemaPath in LoadModelRequest, '%s' attribute must have a string value. Found value %v", jsonAttrModelSchemaPath, modelKey[jsonAttrModelSchemaPath])
+
+	var storageConfig map[string]interface{}
+	// if storageKey is unspecified, check for the existence of a default storage key in the storage config
+	if modelKey.StorageKey == nil {
+		// the default storage key is based on the storage type, so the
+		// type must exist in the parameters
+		storageType, ok := modelKey.StorageParams[parameterKeyType]
+		if !ok {
+			return nil, fmt.Errorf("Predictor Storage field missing")
+		}
+		// the value for the default key should be populated from secrets associated with the Controller's ServiceAccount
+		defaultStorageKey := fmt.Sprintf("_%s_serviceaccount_secrets", storageType)
+
+		var err error
+		storageConfig, err = s.PullerConfig.GetStorageConfiguration(defaultStorageKey, s.Log)
+		if err != nil {
+			// do not error here, try to load from the parameters only
+			storageConfig = map[string]interface{}{}
+		}
+	} else {
+		var err error
+		storageConfig, err = s.PullerConfig.GetStorageConfiguration(*modelKey.StorageKey, s.Log)
+		if err != nil {
+			// if key was specified, but we could not find it, that is an error
+			return nil, fmt.Errorf("Did not find storage config for key %s: %w", *modelKey.StorageKey, err)
 		}
 	}
-	storageKey, ok := modelKey[jsonAttrModelKeyStorageKey].(string)
+
+	// DEPRECATED: allow top-level bucket key for backwards compatibility
+	if modelKey.Bucket != "" {
+		storageConfig["bucket"] = modelKey.Bucket
+	}
+
+	// override the storage configs with per-request storage parameters
+	if err := ApplyParameterOverrides(storageConfig, modelKey.StorageParams); err != nil {
+		return nil, fmt.Errorf("Unable to merge storage parameters from the storage config and the Predictor Storage field: %w", err)
+	}
+
+	var storageType string
+	// if we still don't know the storage type, we cannot download the model, so return an error
+	storageType, ok := storageConfig[parameterKeyType].(string)
 	if !ok {
+		// return nil, fmt.Errorf("Unable to determine storage type. Either StorageKey must be set or StorageParameters must contain the 'type' parameter")
 		return nil, fmt.Errorf("Predictor Storage field missing")
-	}
-
-	storageConfig, err := s.PullerConfig.GetStorageConfiguration(storageKey, s.Log)
-	if err != nil {
-		return nil, err
-	}
-
-	// override storage config with per-request parameters
-	//  check "storage_params" first, but also check the top-level "bucket" key if
-	//  "storage_params" doesn't exist for backwards compatibility
-	if storageParams, ok := modelKey[jsonAttrStorageParams].(map[string]interface{}); ok {
-		if bucketName, ok1 := storageParams[jsonAttrModelKeyBucket]; ok1 {
-			storageConfig.Set("bucket", bucketName)
-		}
-	} else if bucketName, ok := modelKey[jsonAttrModelKeyBucket]; ok {
-		// return error if key exists but it is not a string
-		if _, ok1 := bucketName.(string); !ok1 {
-			return nil, fmt.Errorf("Invalid modelKey in LoadModelRequest, '%s' attribute must have a string value. Found value %v", jsonAttrModelKeyBucket, modelKey[jsonAttrModelKeyBucket])
-		} else {
-			storageConfig.Set("bucket", bucketName)
-		}
-	}
-
-	modelDir, joinErr := util.SecureJoin(s.PullerConfig.RootModelDir, req.ModelId)
-	if joinErr != nil {
-		return nil, fmt.Errorf("Error joining paths '%s' and '%s': %v", s.PullerConfig.RootModelDir, req.ModelId, joinErr)
 	}
 
 	// build and execute the pull command
@@ -125,18 +139,23 @@ func (s *Puller) ProcessLoadModelRequest(req *mmesh.LoadModelRequest) (*mmesh.Lo
 	// name the local files based on the last element of the paths
 	// TODO: should have some sanitization for filenames
 	modelPathFilename := filepath.Base(req.ModelPath)
-	schemaPathFilename := filepath.Base(schemaPath)
-	if modelPathFilename == schemaPathFilename {
-		schemaPathFilename = "_schema.json"
-	}
-
 	targets := []pullman.Target{
 		{
 			RemotePath: req.ModelPath,
 			LocalPath:  modelPathFilename,
 		},
 	}
-	if schemaPath != "" {
+
+	// if included, add the schema to the pull
+	var schemaPathFilename string
+	if modelKey.SchemaPath != nil {
+		schemaPath := *modelKey.SchemaPath
+		schemaPathFilename = filepath.Base(schemaPath)
+		// if the names match, generate an internal name
+		if modelPathFilename == schemaPathFilename {
+			schemaPathFilename = "_schema.json"
+		}
+
 		schemaTarget := pullman.Target{
 			RemotePath: schemaPath,
 			LocalPath:  schemaPathFilename,
@@ -144,8 +163,13 @@ func (s *Puller) ProcessLoadModelRequest(req *mmesh.LoadModelRequest) (*mmesh.Lo
 		targets = append(targets, schemaTarget)
 	}
 
+	modelDir, joinErr := util.SecureJoin(s.PullerConfig.RootModelDir, req.ModelId)
+	if joinErr != nil {
+		return nil, fmt.Errorf("Error joining paths '%s' and '%s': %v", s.PullerConfig.RootModelDir, req.ModelId, joinErr)
+	}
+
 	pullCommand := pullman.PullCommand{
-		RepositoryConfig: storageConfig,
+		RepositoryConfig: pullman.NewRepositoryConfig(storageType, storageConfig),
 		Directory:        modelDir,
 		Targets:          targets,
 	}
@@ -162,19 +186,19 @@ func (s *Puller) ProcessLoadModelRequest(req *mmesh.LoadModelRequest) (*mmesh.Lo
 	req.ModelPath = modelFullPath
 
 	// if it was included, update schema path to an absolute path in the local filesystem
-	if schemaPath != "" {
+	if modelKey.SchemaPath != nil {
 		schemaFullPath, joinErr := util.SecureJoin(modelDir, schemaPathFilename)
 		if joinErr != nil {
 			return nil, fmt.Errorf("Error joining paths '%s' and '%s': %w", modelDir, schemaPathFilename, joinErr)
 		}
-		modelKey[jsonAttrModelSchemaPath] = schemaFullPath
+		modelKey.SchemaPath = &schemaFullPath
 	}
 
 	// update the model key to add the disk size
 	if size, err1 := getModelDiskSize(modelFullPath); err1 != nil {
 		s.Log.Info("Model disk size will not be included in the LoadModelRequest due to error", "model_key", modelKey, "error", err1)
 	} else {
-		modelKey[jsonAttrModelKeyDiskSizeBytes] = size
+		modelKey.DiskSizeBytes = size
 	}
 
 	// rewrite the ModelKey JSON with any updates that have been made

--- a/model-serving-puller/puller/puller.go
+++ b/model-serving-puller/puller/puller.go
@@ -86,7 +86,7 @@ func NewPullerFromConfig(log logr.Logger, config *PullerConfiguration) *Puller {
 func (s *Puller) ProcessLoadModelRequest(req *mmesh.LoadModelRequest) (*mmesh.LoadModelRequest, error) {
 	var modelKey ModelKeyInfo
 	if parseErr := json.Unmarshal([]byte(req.ModelKey), &modelKey); parseErr != nil {
-		return nil, fmt.Errorf("Invalid modelKey in LoadModelRequest. Error processing JSON '%s': %s", req.ModelKey, parseErr)
+		return nil, fmt.Errorf("Invalid modelKey in LoadModelRequest. Error processing JSON '%s': %w", req.ModelKey, parseErr)
 	}
 
 	var storageConfig map[string]interface{}

--- a/model-serving-puller/puller/puller_test.go
+++ b/model-serving-puller/puller/puller_test.go
@@ -430,8 +430,8 @@ func Test_ProcessLoadModelRequest_DefaultStorageKey(t *testing.T) {
 	err := ioutil.WriteFile(defaultConfigFile, []byte(`{"type": "typeless-default"}`), 0555)
 	assert.NoError(t, err)
 	defer func() {
-		err := os.Remove(defaultConfigFile)
-		assert.NoError(t, err)
+		errd := os.Remove(defaultConfigFile)
+		assert.NoError(t, errd)
 	}()
 
 	p, mockPuller := newPullerWithMock(t)

--- a/model-serving-puller/puller/puller_test.go
+++ b/model-serving-puller/puller/puller_test.go
@@ -82,7 +82,7 @@ func Test_ProcessLoadModelRequest_Success_SingleFileModel(t *testing.T) {
 		ModelKey:  `{"disk_size_bytes":60,"storage_key":"myStorage","storage_params":{"bucket":"bucket1"}}`,
 	}
 
-	expectedConfig := pullman.NewRepositoryConfig("s3")
+	expectedConfig := pullman.NewRepositoryConfig("s3", nil)
 	expectedConfig.Set("access_key_id", "")
 	expectedConfig.Set("secret_access_key", "")
 	expectedConfig.Set("endpoint_url", "")
@@ -125,7 +125,7 @@ func Test_ProcessLoadModelRequest_Success_MultiFileModel(t *testing.T) {
 		ModelKey:  `{"disk_size_bytes":60,"storage_key":"myStorage","storage_params":{"bucket":"bucket1"}}`,
 	}
 
-	expectedConfig := pullman.NewRepositoryConfig("s3")
+	expectedConfig := pullman.NewRepositoryConfig("s3", nil)
 	expectedConfig.Set("access_key_id", "")
 	expectedConfig.Set("secret_access_key", "")
 	expectedConfig.Set("endpoint_url", "")
@@ -170,7 +170,7 @@ func Test_ProcessLoadModelRequest_SuccessWithSchema(t *testing.T) {
 		ModelKey:  fmt.Sprintf(`{"disk_size_bytes":0,"schema_path":"%s","storage_key":"myStorage","storage_params":{"bucket":"bucket1"}}`, expectedSchemaPath),
 	}
 
-	expectedConfig := pullman.NewRepositoryConfig("s3")
+	expectedConfig := pullman.NewRepositoryConfig("s3", nil)
 	expectedConfig.Set("access_key_id", "")
 	expectedConfig.Set("secret_access_key", "")
 	expectedConfig.Set("endpoint_url", "")
@@ -217,7 +217,7 @@ func Test_ProcessLoadModelRequest_SuccessWithBucket(t *testing.T) {
 		ModelKey:  `{"bucket":"bucket1","disk_size_bytes":60,"storage_key":"myStorage"}`,
 	}
 
-	expectedConfig := pullman.NewRepositoryConfig("s3")
+	expectedConfig := pullman.NewRepositoryConfig("s3", nil)
 	expectedConfig.Set("access_key_id", "")
 	expectedConfig.Set("secret_access_key", "")
 	expectedConfig.Set("endpoint_url", "")
@@ -260,7 +260,7 @@ func Test_ProcessLoadModelRequest_SuccessNoBucket(t *testing.T) {
 		ModelKey:  `{"disk_size_bytes":60,"storage_key":"myStorage","storage_params":{}}`,
 	}
 
-	expectedConfig := pullman.NewRepositoryConfig("s3")
+	expectedConfig := pullman.NewRepositoryConfig("s3", nil)
 	expectedConfig.Set("access_key_id", "")
 	expectedConfig.Set("secret_access_key", "")
 	expectedConfig.Set("endpoint_url", "")
@@ -303,7 +303,7 @@ func Test_ProcessLoadModelRequest_SuccessNoBucketNoStorageParams(t *testing.T) {
 		ModelKey:  `{"disk_size_bytes":60,"storage_key":"myStorage"}`,
 	}
 
-	expectedConfig := pullman.NewRepositoryConfig("s3")
+	expectedConfig := pullman.NewRepositoryConfig("s3", nil)
 	expectedConfig.Set("access_key_id", "")
 	expectedConfig.Set("secret_access_key", "")
 	expectedConfig.Set("endpoint_url", "")

--- a/model-serving-puller/testdata/storage-config/_test-default-type_serviceaccount_secrets
+++ b/model-serving-puller/testdata/storage-config/_test-default-type_serviceaccount_secrets
@@ -1,0 +1,4 @@
+{
+  "type": "test-default-type",
+  "default": "value"
+}

--- a/model-serving-puller/testdata/storage-config/default_test-default-type
+++ b/model-serving-puller/testdata/storage-config/default_test-default-type
@@ -1,4 +1,4 @@
 {
   "type": "test-default-type",
-  "default": "value"
+  "default": "typed"
 }

--- a/model-serving-puller/testdata/storage-config/genericParameters
+++ b/model-serving-puller/testdata/storage-config/genericParameters
@@ -1,0 +1,8 @@
+{
+  "type": "generic",
+  "key": "sc_value",
+  "struct": {
+    "s1_key": "sc_s1_value",
+    "s2_key": "sc_s2_value"
+  }
+}

--- a/pullman/config.go
+++ b/pullman/config.go
@@ -52,9 +52,14 @@ type RepositoryConfig struct {
 // RepositoryConfig implements Config
 var _ Config = (*RepositoryConfig)(nil)
 
-func NewRepositoryConfig(storageType string) *RepositoryConfig {
+func NewRepositoryConfig(storageType string, config map[string]interface{}) *RepositoryConfig {
+	if config == nil {
+		config = make(map[string]interface{})
+	}
+	// storageType takes priority
+	config[storageTypeKey] = storageType
 	return &RepositoryConfig{
-		config:      map[string]interface{}{storageTypeKey: storageType},
+		config:      config,
 		storageType: storageType,
 	}
 }

--- a/pullman/pullman_test.go
+++ b/pullman/pullman_test.go
@@ -49,7 +49,7 @@ func Test_UseTwoClients_WithCompatibleConfigs(t *testing.T) {
 	ckey := ""
 	msp.RegisterMockClient(ckey, mrc)
 
-	mrcConfig := NewRepositoryConfig(mockProviderType)
+	mrcConfig := NewRepositoryConfig(mockProviderType, nil)
 	mrcConfig.Set(mockConfigKey, ckey)
 
 	{
@@ -90,13 +90,13 @@ func Test_UseTwoClients_WithIncompatibleConfigs(t *testing.T) {
 	mrc1 := NewMockRepositoryClient(ctrl)
 	key1 := "first key"
 	msp.RegisterMockClient(key1, mrc1)
-	mrcConfig1 := NewRepositoryConfig(mockProviderType)
+	mrcConfig1 := NewRepositoryConfig(mockProviderType, nil)
 	mrcConfig1.Set(mockConfigKey, key1)
 
 	mrc2 := NewMockRepositoryClient(ctrl)
 	key2 := "second key"
 	msp.RegisterMockClient(key2, mrc2)
-	mrcConfig2 := NewRepositoryConfig(mockProviderType)
+	mrcConfig2 := NewRepositoryConfig(mockProviderType, nil)
 	mrcConfig2.Set(mockConfigKey, key2)
 
 	{
@@ -134,7 +134,7 @@ func Test_Errors_InvalidConfig(t *testing.T) {
 	mrc := NewMockRepositoryClient(ctrl)
 	key := ""
 	msp.RegisterMockClient(key, mrc)
-	mrcConfig := NewRepositoryConfig(mockProviderType)
+	mrcConfig := NewRepositoryConfig(mockProviderType, nil)
 	errString := "mock error for an invalid configuration"
 	mrcConfig.Set(mockConfigError, errors.New(errString))
 

--- a/pullman/storageproviders/http/provider_test.go
+++ b/pullman/storageproviders/http/provider_test.go
@@ -92,7 +92,7 @@ func Test_Download_SimpleFile(t *testing.T) {
 	_, _, testRepo, mockClient, _ := newTestMocks(t)
 
 	testURL := "http://someurl:8080"
-	c := pullman.NewRepositoryConfig("http")
+	c := pullman.NewRepositoryConfig("http", nil)
 	c.Set("url", testURL)
 
 	downloadDir := filepath.Join("test", "output")
@@ -120,7 +120,7 @@ func Test_GetKey(t *testing.T) {
 	provider := httpProvider{}
 
 	createTestConfig := func() *pullman.RepositoryConfig {
-		config := pullman.NewRepositoryConfig("http")
+		config := pullman.NewRepositoryConfig("http", nil)
 		config.Set(configURL, "http://some.url")
 		config.Set(configHeaders, map[string]string{"header": "value"})
 		config.Set(configCertificate, "<certificate>")

--- a/pullman/storageproviders/s3/provider_test.go
+++ b/pullman/storageproviders/s3/provider_test.go
@@ -42,7 +42,7 @@ func Test_Download_SimpleDirectory(t *testing.T) {
 	s3rc, mdf := newS3RepositoryClientWithMock(t)
 
 	bucket := "bucket"
-	c := pullman.NewRepositoryConfig("s3")
+	c := pullman.NewRepositoryConfig("s3", nil)
 	c.Set("bucket", bucket)
 
 	downloadDir := filepath.Join("test", "output")
@@ -82,7 +82,7 @@ func Test_Download_MultipleTargets(t *testing.T) {
 	s3rc, mdf := newS3RepositoryClientWithMock(t)
 
 	bucket := "bucket"
-	c := pullman.NewRepositoryConfig("s3")
+	c := pullman.NewRepositoryConfig("s3", nil)
 	c.Set("bucket", bucket)
 
 	downloadDir := filepath.Join("test", "output")
@@ -174,7 +174,7 @@ func Test_GetKey(t *testing.T) {
 	provider := s3Provider{}
 
 	createTestConfig := func() *pullman.RepositoryConfig {
-		config := pullman.NewRepositoryConfig("s3")
+		config := pullman.NewRepositoryConfig("s3", nil)
 		config.Set(configAccessKeyID, "access key")
 		config.Set(configSecretAccessKey, "secert key")
 		config.Set(configEndpoint, "https://s3.example.service")


### PR DESCRIPTION
#### Motivation

This is related to the changes to support the new StorageSpec proposal discussed in [this Design Doc](https://docs.google.com/document/d/1rYNh93XNMRp8YaR56m-_zK3bqpZhhGKgpVbLPPsi-Ow/edit#heading=h.gb4md09ddljj). The changes include generalizing the storage config overrides to support more than just  changing the s3 bucket and defaulting the value for the storage key to support existing KServe style storage configurations.

#### Modifications

- support general overriding of storage configurations from load model request (instead of just `bucket`)
  - support a simple dotpath style for overriding storage parameters nested in a struct
- make `ModelKey.storage_key` optional in the request
  - if no value for `ModelKey.storage_key` is specified in the request, check for a default storage key: `default` if no type specified in the parameters `default_{{type}}` if a type is specified. Use it if it exists, but do not error if it doesn't (attempt to continue with just the parameters in `ModelKey.storage_params`)
    - this change matches up with [this change](https://github.com/kserve/kserve/commit/93ff7bb99e653ee055cd6362c5d5362e041276e9#diff-84f9a9cc3ee64522b5d123cc86a5f4348213bd9ac1b892af223eab1142562002R90-R103) in `kserve/kserve`
- define `ModelKeyInfo` struct to represent the object parsed from JSON
- a pullman.RepositoryConfig can now be created with a `map[string]interface{}` instead of having to `Set` each key-value pair.
- also includes some refactors to the puller tests to simplify them and improve failure messages using a GoMock matcher for a PullCommand

#### Result

These changes pave the way for adding support for more storage types and supporting predictors using Kubeflow Serving style storage configurations.