### PR TITLE
chore: enable gcs and http in model puller

### DIFF
--- a/model-serving-puller/puller/puller.go
+++ b/model-serving-puller/puller/puller.go
@@ -27,6 +27,8 @@ import (
 	"github.com/kserve/modelmesh-runtime-adapter/internal/proto/mmesh"
 	"github.com/kserve/modelmesh-runtime-adapter/internal/util"
 	"github.com/kserve/modelmesh-runtime-adapter/pullman"
+	_ "github.com/kserve/modelmesh-runtime-adapter/pullman/storageproviders/gcs"
+	_ "github.com/kserve/modelmesh-runtime-adapter/pullman/storageproviders/http"
 	_ "github.com/kserve/modelmesh-runtime-adapter/pullman/storageproviders/s3"
 )
 


### PR DESCRIPTION
#### Motivation

We want to have the model puller support gcs and http storage types.

#### Modifications

Import the gcs and http providers in the puller in order to register their types.

#### Result

The model-serving-puller can now handle gcs and http types.