### PR TITLE
feat: Enable ModelMetadata endpoint

### DIFF
--- a/model-mesh-mlserver-adapter/server/server.go
+++ b/model-mesh-mlserver-adapter/server/server.go
@@ -526,6 +526,7 @@ func (s *MLServerAdapterServer) RuntimeStatus(ctx context.Context, req *mmesh.Ru
 	mis := make(map[string]*mmesh.RuntimeStatusResponse_MethodInfo)
 
 	mis[mlserverServiceName+"/ModelInfer"] = &mmesh.RuntimeStatusResponse_MethodInfo{IdInjectionPath: path1}
+	mis[mlserverServiceName+"/ModelMetadata"] = &mmesh.RuntimeStatusResponse_MethodInfo{IdInjectionPath: path1}
 	runtimeStatus.MethodInfos = mis
 
 	log.Info("runtimeStatus", "Status", runtimeStatus)

--- a/model-mesh-triton-adapter/server/server.go
+++ b/model-mesh-triton-adapter/server/server.go
@@ -264,6 +264,7 @@ func (s *TritonAdapterServer) RuntimeStatus(ctx context.Context, req *mmesh.Runt
 
 	// only support Transform for now
 	mis[tritonServiceName+"/ModelInfer"] = &mmesh.RuntimeStatusResponse_MethodInfo{IdInjectionPath: path1}
+	mis[tritonServiceName+"/ModelMetadata"] = &mmesh.RuntimeStatusResponse_MethodInfo{IdInjectionPath: path1}
 	runtimeStatus.MethodInfos = mis
 
 	log.Info("runtimeStatus", "Status", runtimeStatus)


### PR DESCRIPTION
MLServer and Triton both support the ModelMetadata endpoint, so we should surface it for end users.

Here, the `ModelMetadata` endpoint is enabled in the adapter logic for MLServer and Triton.

Ref: https://github.com/kserve/modelmesh-serving/issues/136

