### PR TITLE
chore: Enable azure storage provider in puller

### DIFF
--- a/model-serving-puller/puller/puller.go
+++ b/model-serving-puller/puller/puller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kserve/modelmesh-runtime-adapter/internal/proto/mmesh"
 	"github.com/kserve/modelmesh-runtime-adapter/internal/util"
 	"github.com/kserve/modelmesh-runtime-adapter/pullman"
+	_ "github.com/kserve/modelmesh-runtime-adapter/pullman/storageproviders/azure"
 	_ "github.com/kserve/modelmesh-runtime-adapter/pullman/storageproviders/gcs"
 	_ "github.com/kserve/modelmesh-runtime-adapter/pullman/storageproviders/http"
 	_ "github.com/kserve/modelmesh-runtime-adapter/pullman/storageproviders/s3"


### PR DESCRIPTION
Azure support was added in pullman. This enables its use in the puller sidecar.
