### PR TITLE
tidy: Clean up various adapter/puller logic

### DIFF
--- a/internal/util/connect.go
+++ b/internal/util/connect.go
@@ -1,0 +1,30 @@
+// Copyright 2021 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package util
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+func ResolveLocalGrpcEndpoint(servingRuntimeEndpoint string) (string, error) {
+	if match, _ := regexp.MatchString("^port:[0-9]+$", servingRuntimeEndpoint); match {
+		return strings.Replace(servingRuntimeEndpoint, "port", "localhost", 1), nil
+	}
+	if !strings.HasPrefix(servingRuntimeEndpoint, "unix:") {
+		return "", errors.New("Invalid Endpoint: " + servingRuntimeEndpoint)
+	}
+	return servingRuntimeEndpoint, nil // Return as-is in unix: prefix case
+}

--- a/internal/util/connect_test.go
+++ b/internal/util/connect_test.go
@@ -1,0 +1,39 @@
+// Copyright 2021 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package util
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestResolveLocalGrpcEndpoint(t *testing.T) {
+	testCases := []struct {
+		endpoint string
+		expected string
+	}{
+		{"port:8085", "localhost:8085"},
+		{"unix:/socket/path", "unix:/socket/path"},
+	}
+	for _, tc := range testCases {
+		got, err := ResolveLocalGrpcEndpoint(tc.endpoint)
+		if err != nil {
+			fmt.Println("Have err", err)
+			t.Fatalf("error performing ResolveLocalGrpcEndpoint: %v", err)
+		}
+		if got != tc.expected {
+			t.Errorf("ResolveLocalGrpcEndpoint(%v) = %v; expected %v", tc.endpoint, got, tc.expected)
+		}
+	}
+}

--- a/internal/util/loadmodel.go
+++ b/internal/util/loadmodel.go
@@ -33,8 +33,7 @@ const (
 func GetModelType(req *mmesh.LoadModelRequest, log logr.Logger) string {
 	modelType := req.ModelType
 	var modelKey map[string]interface{}
-	err := json.Unmarshal([]byte(req.ModelKey), &modelKey)
-	if err != nil {
+	if err := json.Unmarshal([]byte(req.ModelKey), &modelKey); err != nil {
 		log.Info("The model type will fall back to LoadModelRequest.ModelType as LoadModelRequest.ModelKey value is not valid JSON", "LoadModelRequest.ModelType", req.ModelType, "LoadModelRequest.ModelKey", req.ModelKey, "Error", err)
 	} else if modelKey[modelTypeJSONKey] == nil {
 		log.Info("The model type will fall back to LoadModelRequest.ModelType as LoadModelRequest.ModelKey does not have specified attribute", "LoadModelRequest.ModelType", req.ModelType, "attribute", modelTypeJSONKey)
@@ -61,10 +60,8 @@ func GetSchemaPath(req *mmesh.LoadModelRequest) (string, error) {
 	}
 
 	schemaPath, ok := modelKey[schemaPathJSONKey].(string)
-	if !ok {
-		if modelKey[schemaPathJSONKey] != nil {
-			return "", fmt.Errorf("Invalid schemaPath in LoadModelRequest, '%s' attribute must have a string value. Found value %v", schemaPathJSONKey, modelKey[schemaPathJSONKey])
-		}
+	if !ok && modelKey[schemaPathJSONKey] != nil {
+		return "", fmt.Errorf("Invalid schemaPath in LoadModelRequest, '%s' attribute must have a string value. Found value %v", schemaPathJSONKey, modelKey[schemaPathJSONKey])
 	}
 
 	return schemaPath, nil
@@ -75,8 +72,7 @@ func CalcMemCapacity(reqModelKey string, defaultSize int, multiplier float64, lo
 	// but first set the default to fall back on if we cannot get the disk size.
 	size := uint64(defaultSize)
 	var modelKey map[string]interface{}
-	err := json.Unmarshal([]byte(reqModelKey), &modelKey)
-	if err != nil {
+	if err := json.Unmarshal([]byte(reqModelKey), &modelKey); err != nil {
 		log.Info("'SizeInBytes' will be defaulted as LoadModelRequest.ModelKey value is not valid JSON", "SizeInBytes", size, "model_key", reqModelKey, "error", err)
 	} else {
 		if modelKey[diskSizeBytesJSONKey] != nil {

--- a/model-mesh-mlserver-adapter/main.go
+++ b/model-mesh-mlserver-adapter/main.go
@@ -25,8 +25,7 @@ import (
 )
 
 func main() {
-	log := zap.New(zap.UseDevMode(true))
-	log = log.WithName("MLServer Adapter")
+	log := zap.New(zap.UseDevMode(true)).WithName("MLServer Adapter")
 
 	adapterConfig, err := server.GetAdapterConfigurationFromEnv(log)
 	if err != nil {
@@ -46,14 +45,11 @@ func main() {
 
 	log.Info("Adapter will run at port", "port", adapterConfig.Port, "MLServer port", adapterConfig.MLServerPort)
 
-	var opts []grpc.ServerOption
-
-	log.Info("Adapter gRPC Server Registered...")
-	grpcServer := grpc.NewServer(opts...)
+	grpcServer := grpc.NewServer()
 	mmesh.RegisterModelRuntimeServer(grpcServer, MLServer)
-	err = grpcServer.Serve(lis)
+	log.Info("Adapter gRPC Server registered, now serving")
 
-	if err != nil {
+	if err = grpcServer.Serve(lis); err != nil {
 		log.Error(err, "*** Adapter terminated with error ")
 	} else {
 		log.Info("*** Adapter terminated")

--- a/model-mesh-mlserver-adapter/server/adaptmodellayout_test.go
+++ b/model-mesh-mlserver-adapter/server/adaptmodellayout_test.go
@@ -414,6 +414,7 @@ func TestAdaptModelLayoutForRuntime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not remove root model dir %s due to error %v", generatedTestdataDir, err)
 	}
+	mlServerRootModelDir := filepath.Join(generatedTestdataDir, mlserverModelSubdir)
 	for _, tt := range adaptModelLayoutTests {
 		t.Run(tt.ModelID, func(t *testing.T) {
 			var err1 error
@@ -430,17 +431,17 @@ func TestAdaptModelLayoutForRuntime(t *testing.T) {
 			if tt.SchemaPath != "" {
 				schemaFullPath = filepath.Join(tt.getSourceDir(), tt.SchemaPath)
 			}
-			err1 = adaptModelLayoutForRuntime(generatedTestdataDir, tt.ModelID, tt.ModelType, modelFullPath, schemaFullPath, log)
+			err1 = adaptModelLayoutForRuntime(mlServerRootModelDir, tt.ModelID, tt.ModelType, modelFullPath, schemaFullPath, log)
 
 			// assert no error
 			if err1 != nil {
-				t.Error("adaptModelLayoutForRuntime failed with error:", err1)
+				t.Fatal("adaptModelLayoutForRuntime failed with error:", err1)
 			}
 
 			// assert that the expected links exist and are correct
 			generatedFiles, err1 := getFilesInDir(tt.getTargetDir())
 			if err1 != nil {
-				t.Error(err1)
+				t.Fatal(err1)
 			}
 			for _, file := range tt.ExpectedFiles {
 				// assert that the expected file exists

--- a/model-mesh-mlserver-adapter/server/server.go
+++ b/model-mesh-mlserver-adapter/server/server.go
@@ -348,7 +348,7 @@ func adaptModelLayout(modelID, modelType, modelPath, schemaPath, targetDir strin
 	}
 
 	log.Info("Adapted model directory for standalone file/dir", "sourcePath", modelPath,
-		"isDir", isDir, "symLinkPath", modelType, "generatedSettingsFile", target)
+		"isDir", isDir, "symLinkPath", linkPath, "generatedSettingsFile", target)
 
 	return nil
 }

--- a/model-mesh-ovms-adapter/main.go
+++ b/model-mesh-ovms-adapter/main.go
@@ -25,8 +25,7 @@ import (
 )
 
 func main() {
-	log := zap.New(zap.UseDevMode(true))
-	log = log.WithName("OpenVINO Adapter")
+	log := zap.New(zap.UseDevMode(true)).WithName("OpenVINO Adapter")
 
 	adapterConfig, err := server.GetAdapterConfigurationFromEnv(log)
 	if err != nil {
@@ -46,11 +45,9 @@ func main() {
 
 	grpcServer := grpc.NewServer()
 	mmesh.RegisterModelRuntimeServer(grpcServer, server)
-	log.Info("Adapter gRPC Server Registered...")
+	log.Info("Adapter gRPC Server Registered, now serving")
 
-	err = grpcServer.Serve(lis)
-
-	if err != nil {
+	if err = grpcServer.Serve(lis); err != nil {
 		log.Error(err, "*** Adapter terminated with error ")
 	} else {
 		log.Info("*** Adapter terminated")

--- a/model-mesh-ovms-adapter/server/adaptmodellayout.go
+++ b/model-mesh-ovms-adapter/server/adaptmodellayout.go
@@ -31,9 +31,9 @@ func adaptModelLayoutForRuntime(ctx context.Context, rootModelDir, modelID, mode
 	// convert to lower case and remove anything after the :
 	modelType = strings.ToLower(strings.Split(modelType, ":")[0])
 
-	ovmsModelIDDir, err := util.SecureJoin(rootModelDir, ovmsModelSubdir, modelID)
+	ovmsModelIDDir, err := util.SecureJoin(rootModelDir, modelID)
 	if err != nil {
-		log.Error(err, "Unable to securely join", "rootModelDir", rootModelDir, "ovmsModelSubdir", ovmsModelSubdir, "modelID", modelID)
+		log.Error(err, "Unable to securely join", "rootModelDir", rootModelDir, "modelID", modelID)
 		return err
 	}
 	// clean up and then create directory where the rewritten model repo will live

--- a/model-mesh-ovms-adapter/server/adaptmodellayout_test.go
+++ b/model-mesh-ovms-adapter/server/adaptmodellayout_test.go
@@ -88,6 +88,7 @@ func (tt adaptModelLayoutTestCase) writeSchemaFile(t *testing.T) {
 }
 
 func TestAdaptModelLayoutForRuntime(t *testing.T) {
+	ovmsRootModelDir := filepath.Join(generatedTestdataDir, ovmsModelSubdir)
 	for _, tt := range adaptModelLayoutTests {
 		t.Run(tt.ModelID, func(t *testing.T) {
 			// cleanup the source directory before running each test
@@ -103,7 +104,7 @@ func TestAdaptModelLayoutForRuntime(t *testing.T) {
 			if tt.SchemaPath != "" {
 				schemaFullPath = filepath.Join(tt.getSourceDir(), tt.SchemaPath)
 			}
-			err = adaptModelLayoutForRuntime(context.Background(), generatedTestdataDir, tt.ModelID, tt.ModelType, modelFullPath, schemaFullPath, log)
+			err = adaptModelLayoutForRuntime(context.Background(), ovmsRootModelDir, tt.ModelID, tt.ModelType, modelFullPath, schemaFullPath, log)
 
 			if tt.ExpectError && err == nil {
 				t.Fatal("ExpectError is true, but no error was returned")
@@ -127,6 +128,7 @@ func TestAdaptModelLayoutForRuntime_Multiple(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not remove root model dir %s due to error %v", generatedTestdataDir, err)
 	}
+	ovmsRootModelDir := filepath.Join(generatedTestdataDir, ovmsModelSubdir)
 
 	// first create all the source files
 	for _, tt := range adaptModelLayoutTests {
@@ -141,7 +143,7 @@ func TestAdaptModelLayoutForRuntime_Multiple(t *testing.T) {
 		if tt.SchemaPath != "" {
 			schemaFullPath = filepath.Join(tt.getSourceDir(), tt.SchemaPath)
 		}
-		err = adaptModelLayoutForRuntime(ctx, generatedTestdataDir, tt.ModelID, tt.ModelType, modelFullPath, schemaFullPath, log)
+		err = adaptModelLayoutForRuntime(ctx, ovmsRootModelDir, tt.ModelID, tt.ModelType, modelFullPath, schemaFullPath, log)
 		if tt.ExpectError && err == nil {
 			t.Fatal("ExpectError is true, but no error was returned")
 		}

--- a/model-mesh-triton-adapter/main.go
+++ b/model-mesh-triton-adapter/main.go
@@ -25,8 +25,7 @@ import (
 )
 
 func main() {
-	log := zap.New(zap.UseDevMode(true))
-	log = log.WithName("Triton Adapter")
+	log := zap.New(zap.UseDevMode(true)).WithName("Triton Adapter")
 
 	adapterConfig, err := server.GetAdapterConfigurationFromEnv(log)
 	if err != nil {
@@ -46,14 +45,11 @@ func main() {
 
 	log.Info("Adapter will run at port", "port", adapterConfig.Port, "Triton port", adapterConfig.TritonPort)
 
-	var opts []grpc.ServerOption
-
-	log.Info("Adapter gRPC Server Registered...")
-	grpcServer := grpc.NewServer(opts...)
+	grpcServer := grpc.NewServer()
 	mmesh.RegisterModelRuntimeServer(grpcServer, TAServer)
-	err = grpcServer.Serve(lis)
+	log.Info("Adapter gRPC Server registered, now serving")
 
-	if err != nil {
+	if err = grpcServer.Serve(lis); err != nil {
 		log.Error(err, "*** Adapter terminated with error ")
 	} else {
 		log.Info("*** Adapter terminated")

--- a/model-mesh-triton-adapter/server/adaptmodellayout.go
+++ b/model-mesh-triton-adapter/server/adaptmodellayout.go
@@ -60,9 +60,9 @@ func adaptModelLayoutForRuntime(ctx context.Context, rootModelDir, modelID, mode
 	// convert to lower case and remove anything after the :
 	modelType = strings.ToLower(strings.Split(modelType, ":")[0])
 
-	tritonModelIDDir, err := util.SecureJoin(rootModelDir, tritonModelSubdir, modelID)
+	tritonModelIDDir, err := util.SecureJoin(rootModelDir, modelID)
 	if err != nil {
-		log.Error(err, "Unable to securely join", "rootModelDir", rootModelDir, "tritonModelSubdir", tritonModelSubdir, "modelID", modelID)
+		log.Error(err, "Unable to securely join", "rootModelDir", rootModelDir, "modelID", modelID)
 		return err
 	}
 	// clean up and then create directory where the rewritten model repo will live

--- a/model-mesh-triton-adapter/server/adaptmodellayout_test.go
+++ b/model-mesh-triton-adapter/server/adaptmodellayout_test.go
@@ -178,6 +178,7 @@ func (tt adaptModelLayoutTestCase) writeSchemaFile(t *testing.T) {
 }
 
 func TestAdaptModelLayoutForRuntime(t *testing.T) {
+	tritonRootModelDir := filepath.Join(generatedTestdataDir, tritonModelSubdir)
 	for _, tt := range adaptModelLayoutTests {
 		t.Run(tt.ModelID, func(t *testing.T) {
 			// cleanup the source directory before running each test
@@ -193,7 +194,7 @@ func TestAdaptModelLayoutForRuntime(t *testing.T) {
 			if tt.SchemaPath != "" {
 				schemaFullPath = filepath.Join(tt.getSourceDir(), tt.SchemaPath)
 			}
-			err = adaptModelLayoutForRuntime(context.Background(), generatedTestdataDir, tt.ModelID, tt.ModelType, modelFullPath, schemaFullPath, log)
+			err = adaptModelLayoutForRuntime(context.Background(), tritonRootModelDir, tt.ModelID, tt.ModelType, modelFullPath, schemaFullPath, log)
 
 			if tt.ExpectError && err == nil {
 				t.Fatal("ExpectError is true, but no error was returned")
@@ -217,6 +218,7 @@ func TestAdaptModelLayoutForRuntime_Multiple(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not remove root model dir %s due to error %v", generatedTestdataDir, err)
 	}
+	tritonRootModelDir := filepath.Join(generatedTestdataDir, tritonModelSubdir)
 
 	// first create all the source files
 	for _, tt := range adaptModelLayoutTests {
@@ -231,7 +233,7 @@ func TestAdaptModelLayoutForRuntime_Multiple(t *testing.T) {
 		if tt.SchemaPath != "" {
 			schemaFullPath = filepath.Join(tt.getSourceDir(), tt.SchemaPath)
 		}
-		err = adaptModelLayoutForRuntime(ctx, generatedTestdataDir, tt.ModelID, tt.ModelType, modelFullPath, schemaFullPath, log)
+		err = adaptModelLayoutForRuntime(ctx, tritonRootModelDir, tt.ModelID, tt.ModelType, modelFullPath, schemaFullPath, log)
 		if tt.ExpectError && err == nil {
 			t.Fatal("ExpectError is true, but no error was returned")
 		}

--- a/model-mesh-triton-adapter/server/config.go
+++ b/model-mesh-triton-adapter/server/config.go
@@ -16,6 +16,8 @@ package server
 import (
 	"fmt"
 
+	"github.com/kserve/modelmesh-runtime-adapter/internal/util"
+
 	"github.com/go-logr/logr"
 
 	. "github.com/kserve/modelmesh-runtime-adapter/internal/envconfig"
@@ -61,14 +63,19 @@ func GetAdapterConfigurationFromEnv(log logr.Logger) (*AdapterConfiguration, err
 	adapterConfig.ModelSizeMultiplier = GetEnvFloat(modelSizeMultiplier, defaultModelSizeMultiplier, log)
 	adapterConfig.RuntimeVersion = GetEnvString(runtimeVersion, defaultRuntimeVersion)
 	adapterConfig.LimitModelConcurrency = GetEnvInt(limitPerModelConcurrency, defaultLimitPerModelConcurrency, log)
-	adapterConfig.RootModelDir = GetEnvString(rootModelDir, defaultRootModelDir)
 	adapterConfig.UseEmbeddedPuller = GetEnvBool(useEmbeddedPuller, defaultUseEmbeddedPuller, log)
 
+	var err error
+	adapterConfig.RootModelDir, err = util.SecureJoin(GetEnvString(rootModelDir, defaultRootModelDir), tritonModelSubdir)
+	if err != nil {
+		return nil, fmt.Errorf("Could not construct root model path: %w", err)
+	}
+
 	if adapterConfig.TritonContainerMemReqBytes < 0 {
-		return adapterConfig, fmt.Errorf("%s environment variable must be set to a positive integer, found value %v", tritonContainerMemReqBytes, adapterConfig.TritonContainerMemReqBytes)
+		return nil, fmt.Errorf("%s environment variable must be set to a positive integer, found value %v", tritonContainerMemReqBytes, adapterConfig.TritonContainerMemReqBytes)
 	}
 	if adapterConfig.ModelSizeMultiplier <= 0 {
-		return adapterConfig, fmt.Errorf("%s environment variable must be greater than 0, found value %v", modelSizeMultiplier, adapterConfig.ModelSizeMultiplier)
+		return nil, fmt.Errorf("%s environment variable must be greater than 0, found value %v", modelSizeMultiplier, adapterConfig.ModelSizeMultiplier)
 	}
 	return adapterConfig, nil
 }

--- a/model-serving-puller/puller/puller.go
+++ b/model-serving-puller/puller/puller.go
@@ -248,12 +248,17 @@ func (p *Puller) CleanupModel(modelID string) error {
 		p.Log.Error(err, "Error joining paths", "RootModelDir", p.PullerConfig.RootModelDir, "ModelId", modelID)
 		return err
 	}
-	err = os.RemoveAll(pathToModel)
-	if err != nil {
+	if err = os.RemoveAll(pathToModel); err != nil {
 		p.Log.Error(err, "Model unload failed to delete files from the local filesystem", "local_dir", pathToModel)
 		return fmt.Errorf("Failed to delete model from local filesystem: %w", err)
 	}
 	return nil
+}
+
+func (p *Puller) ClearLocalModelStorage(exclude string) error {
+	return util.ClearDirectoryContents(p.PullerConfig.RootModelDir, func(f os.DirEntry) bool {
+		return f.Name() != exclude
+	})
 }
 
 func (p *Puller) ListModels() ([]string, error) {


### PR DESCRIPTION
#### Motivation

While working on adding built-in adapter support for torchserve, I noticed various things to be added/tidied in the adapter logic.

Note that there's still a lot of simplification that could be done - in particular de-duplication and unification of common logic between the different adapters.

#### Modifications

- Move logic for resolving gRPC endpoint from ServingRuntime endpoint into a utility function
- Change `adapterConfig.RootModelDir` to reference the subdir containing the _adapted_ model files/dirs
- Create the adapter model subdir when the adapter is first created
- Change the initial gRPC connection to the model server(s) to be non-blocking and remove connection test from that context - the `runtimeStatus` func will be called subsequently to determine when the connection/server is ready
- Add logic to `RuntimeStatus` impls and puller to clean up local storage when called (per the SPI contract)
- Add/clean-up some logging, particularly related to `adaptModelLayout` logic
- Inline some if assignments :)
