### PR TITLE
feat: Add pullman PVC storage provider

### DIFF
--- a/model-serving-puller/puller/puller.go
+++ b/model-serving-puller/puller/puller.go
@@ -168,13 +168,7 @@ func (s *Puller) ProcessLoadModelRequest(ctx context.Context, req *mmesh.LoadMod
 		targets = append(targets, schemaTarget)
 	}
 
-	var modelDir string
-	var joinErr error
-	if storageType == "pvc" {
-		modelDir, joinErr = util.SecureJoin("/pvc_mounts", storageConfig["name"].(string), filepath.Dir(req.ModelPath))
-	} else {
-		modelDir, joinErr = util.SecureJoin(s.PullerConfig.RootModelDir, req.ModelId)
-	}
+	modelDir, joinErr := util.SecureJoin(s.PullerConfig.RootModelDir, req.ModelId)
 	if joinErr != nil {
 		return nil, fmt.Errorf("Error joining paths '%s' and '%s': %v", s.PullerConfig.RootModelDir, req.ModelId, joinErr)
 	}
@@ -190,10 +184,13 @@ func (s *Puller) ProcessLoadModelRequest(ctx context.Context, req *mmesh.LoadMod
 	}
 
 	// update model path to an absolute path in the local filesystem
-	modelFullPath, joinErr := util.SecureJoin(modelDir, modelPathFilename)
-	if joinErr != nil {
-		return nil, fmt.Errorf("Error joining paths '%s' and '%s': %w", modelDir, modelPathFilename, joinErr)
-	}
+	// commment out SecureJoin since it doesn't handle symlinks well
+	// modelFullPath, joinErr := util.SecureJoin(modelDir, modelPathFilename)
+	// if joinErr != nil {
+	// 	return nil, fmt.Errorf("Error joining paths '%s' and '%s': %w", modelDir, modelPathFilename, joinErr)
+	// }
+	modelFullPath := modelDir + string(filepath.Separator) + modelPathFilename
+
 	req.ModelPath = modelFullPath
 
 	// if it was included, update schema path to an absolute path in the local filesystem

--- a/model-serving-puller/puller/puller.go
+++ b/model-serving-puller/puller/puller.go
@@ -30,6 +30,7 @@ import (
 	_ "github.com/kserve/modelmesh-runtime-adapter/pullman/storageproviders/azure"
 	_ "github.com/kserve/modelmesh-runtime-adapter/pullman/storageproviders/gcs"
 	_ "github.com/kserve/modelmesh-runtime-adapter/pullman/storageproviders/http"
+	_ "github.com/kserve/modelmesh-runtime-adapter/pullman/storageproviders/pvc"
 	_ "github.com/kserve/modelmesh-runtime-adapter/pullman/storageproviders/s3"
 )
 
@@ -167,7 +168,13 @@ func (s *Puller) ProcessLoadModelRequest(ctx context.Context, req *mmesh.LoadMod
 		targets = append(targets, schemaTarget)
 	}
 
-	modelDir, joinErr := util.SecureJoin(s.PullerConfig.RootModelDir, req.ModelId)
+	var modelDir string
+	var joinErr error
+	if storageType == "pvc" {
+		modelDir, joinErr = util.SecureJoin("/pvc_mounts", storageConfig["name"].(string), filepath.Dir(req.ModelPath))
+	} else {
+		modelDir, joinErr = util.SecureJoin(s.PullerConfig.RootModelDir, req.ModelId)
+	}
 	if joinErr != nil {
 		return nil, fmt.Errorf("Error joining paths '%s' and '%s': %v", s.PullerConfig.RootModelDir, req.ModelId, joinErr)
 	}

--- a/pullman/storageproviders/pvc/provider.go
+++ b/pullman/storageproviders/pvc/provider.go
@@ -1,0 +1,117 @@
+// Copyright 2022 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvcprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/go-logr/logr"
+
+	"github.com/kserve/modelmesh-runtime-adapter/internal/util"
+	"github.com/kserve/modelmesh-runtime-adapter/pullman"
+)
+
+const (
+	// config fields
+	configPVCName      = "name"
+	configPVCMountBase = "pvc_mount_base"
+
+	// defaults
+	defaultPVCMountBase = "/pvc_mounts"
+)
+
+type pvcProvider struct {
+}
+
+// pvcProvider implements StorageProvider
+var _ pullman.StorageProvider = (*pvcProvider)(nil)
+
+func (p pvcProvider) GetKey(config pullman.Config) string {
+	// hash the values of all configurations that go into creating the client
+	// no need to validate the config here
+	pvcName, _ := pullman.GetString(config, configPVCName)
+	pvcMountBase, _ := pullman.GetString(config, configPVCMountBase)
+
+	return pullman.HashStrings(pvcName, pvcMountBase)
+}
+
+func (p pvcProvider) NewRepository(config pullman.Config, log logr.Logger) (pullman.RepositoryClient, error) {
+
+	pvcName, _ := pullman.GetString(config, configPVCName)
+
+	if pvcName == "" {
+		return nil, errors.New("pvc name must be specified")
+	}
+
+	return &pvcRepositoryClient{
+		log: log,
+	}, nil
+}
+
+type pvcRepositoryClient struct {
+	log logr.Logger
+}
+
+// pvcRepositoryClient implements RepositoryClient
+var _ pullman.RepositoryClient = (*pvcRepositoryClient)(nil)
+
+func (r *pvcRepositoryClient) Pull(ctx context.Context, pc pullman.PullCommand) error {
+	targets := pc.Targets
+
+	// Process per-command configuration
+	pvcName, ok := pullman.GetString(pc.RepositoryConfig, configPVCName)
+	if !ok {
+		return fmt.Errorf("required configuration '%s' missing from command", configPVCName)
+	}
+	pvcMountBase, ok := pullman.GetString(pc.RepositoryConfig, configPVCMountBase)
+	if !ok {
+		// use the default value when not provided in repository config
+		pvcMountBase = defaultPVCMountBase
+	}
+
+	pvcDir, joinErr := util.SecureJoin(pvcMountBase, pvcName)
+	if joinErr != nil {
+		return fmt.Errorf("unable to join paths '%s' and '%s': %v", pvcMountBase, pvcName, joinErr)
+	}
+	r.log.V(1).Info("The PVC directory is set", "pvcDir", pvcDir)
+
+	// check the local PVC path /pvcMountBase/pvcName exists
+	_, err := os.ReadDir(pvcDir)
+	if err != nil {
+		return fmt.Errorf("unable to read PVC directory '%s': %w", pvcDir, err)
+	}
+
+	for _, pt := range targets {
+		fullModelPath, joinErr := util.SecureJoin(pvcDir, pt.RemotePath)
+		if joinErr != nil {
+			return fmt.Errorf("unable to join paths '%s' and '%s': %v", pvcDir, pt.RemotePath, joinErr)
+		}
+		r.log.V(1).Info("The model path is set", "fullModelPath", fullModelPath)
+
+		// check the local model path /pvcMountBase/pvcName/modelPath exists
+		if _, err = os.Stat(fullModelPath); os.IsNotExist(err) {
+			return fmt.Errorf("unable to find model local path '%s'", fullModelPath)
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	p := pvcProvider{}
+	pullman.RegisterProvider("pvc", p)
+}

--- a/pullman/storageproviders/pvc/provider.go
+++ b/pullman/storageproviders/pvc/provider.go
@@ -51,9 +51,13 @@ func (p pvcProvider) NewRepository(config pullman.Config, log logr.Logger) (pull
 	}
 
 	fileInfo, err := os.Stat(p.pvcMountBase)
-	if os.IsNotExist(err) {
-		return nil, fmt.Errorf("the PVC mount base '%s' doesn't exist: %w", p.pvcMountBase, err)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("the PVC mount base '%s' doesn't exist: %w", p.pvcMountBase, err)
+		}
+		return nil, fmt.Errorf("failed to access the PVC mount base '%s': %w", p.pvcMountBase, err)
 	}
+
 	if !fileInfo.IsDir() {
 		return nil, fmt.Errorf("the PVC mount base '%s' is not a directory", p.pvcMountBase)
 	}

--- a/pullman/storageproviders/pvc/provider_test.go
+++ b/pullman/storageproviders/pvc/provider_test.go
@@ -1,0 +1,110 @@
+// Copyright 2022 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pvcprovider
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/kserve/modelmesh-runtime-adapter/pullman"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func newPVCProvider(t *testing.T) (pvcProvider, logr.Logger) {
+	p := pvcProvider{}
+	log := zap.New()
+	return p, log
+}
+
+func newPVCRepositoryClient(t *testing.T) *pvcRepositoryClient {
+	log := zap.New()
+	pvcrc := pvcRepositoryClient{
+		log: log,
+	}
+	return &pvcrc
+}
+
+func Test_NewRepository(t *testing.T) {
+	p, log := newPVCProvider(t)
+	c := pullman.NewRepositoryConfig("pvc", nil)
+	c.Set("name", "pvcName")
+	_, err := p.NewRepository(c, log)
+	assert.NoError(t, err)
+}
+
+func Test_Verify_Directory(t *testing.T) {
+	pvcMountBase, _ := os.Getwd()
+	pvcName := "pvcName"
+	modelDir := "modelDir"
+	pvcRc := newPVCRepositoryClient(t)
+	c := pullman.NewRepositoryConfig("pvc", nil)
+	c.Set("name", pvcName)
+	c.Set("pvc_mount_base", pvcMountBase)
+
+	pvcModelDir := pvcMountBase + "/" + pvcName + "/" + modelDir
+
+	inputPullCommand := pullman.PullCommand{
+		RepositoryConfig: c,
+		Directory:        pvcModelDir,
+		Targets: []pullman.Target{
+			{
+				RemotePath: modelDir,
+			},
+		},
+	}
+
+	// should return error because the directory doesn't exist
+	err := pvcRc.Pull(context.Background(), inputPullCommand)
+	assert.Error(t, err)
+
+	err = os.MkdirAll(pvcModelDir, os.ModePerm)
+	assert.NoError(t, err)
+
+	// should not return error because the directory exists
+	err = pvcRc.Pull(context.Background(), inputPullCommand)
+	assert.NoError(t, err)
+
+	err = os.RemoveAll(pvcModelDir)
+	assert.NoError(t, err)
+}
+
+func Test_GetKey(t *testing.T) {
+	provider := pvcProvider{}
+
+	createTestConfig := func() *pullman.RepositoryConfig {
+		config := pullman.NewRepositoryConfig("pvc", nil)
+		config.Set(configPVCName, "pvcName1")
+		return config
+	}
+
+	// should return the same result given the same config
+	t.Run("shouldMatchForSameConfig", func(t *testing.T) {
+		config1 := createTestConfig()
+		config2 := createTestConfig()
+
+		assert.Equal(t, provider.GetKey(config1), provider.GetKey(config2))
+	})
+
+	// changing the pvc name should change the key
+	t.Run("shouldChangeForTokenUri", func(t *testing.T) {
+		config1 := createTestConfig()
+		config2 := createTestConfig()
+		config2.Set(configPVCName, "pvcName2")
+
+		assert.NotEqual(t, provider.GetKey(config1), provider.GetKey(config2))
+	})
+}


### PR DESCRIPTION
Add pullman PVC storage provider to support models in PVC

#### Motivation
Want to serve models located in PVC storage

#### Modifications

- Added a PVC storage provider to the pullman package.
- Updated the puller to check for PVC type and set up modelDir differently.

#### Result
Pullman now supports pulling model files from PVC Storage

#### Related Issues

- https://github.com/kserve/modelmesh-serving/issues/230
- https://github.com/kserve/modelmesh-serving/pull/267