### PR TITLE
fix: correct mlserver uri conversion regardless of filenames

### DIFF
--- a/model-mesh-mlserver-adapter/server/adaptmodellayout_test.go
+++ b/model-mesh-mlserver-adapter/server/adaptmodellayout_test.go
@@ -404,8 +404,8 @@ var adaptModelLayoutTests = []adaptModelLayoutTestCase{
 				},
 			},
 		},
-	}, 
-	
+	},
+
 	// model with filename that alphabetically precedes model-settings.json
 
 	{
@@ -420,7 +420,7 @@ var adaptModelLayoutTests = []adaptModelLayoutTestCase{
 			"name":           "model-name",
 			"implementation": "mlserver_sklearn.SKLearnModel",
 			"parameters": map[string]interface{}{
-				"uri":     "./aaaaa.json",
+				"uri": "./aaaaa.json",
 			},
 		},
 		ExpectedFiles: []string{
@@ -431,7 +431,7 @@ var adaptModelLayoutTests = []adaptModelLayoutTestCase{
 			"name":           "model-filename-precedes-model-settings",
 			"implementation": "mlserver_sklearn.SKLearnModel",
 			"parameters": map[string]interface{}{
-				"uri":     filepath.Join(generatedMlserverModelsDir, "model-filename-precedes-model-settings", "aaaaa.json"),
+				"uri": filepath.Join(generatedMlserverModelsDir, "model-filename-precedes-model-settings", "aaaaa.json"),
 			},
 		},
 	},

--- a/model-mesh-mlserver-adapter/server/adaptmodellayout_test.go
+++ b/model-mesh-mlserver-adapter/server/adaptmodellayout_test.go
@@ -404,6 +404,36 @@ var adaptModelLayoutTests = []adaptModelLayoutTestCase{
 				},
 			},
 		},
+	}, 
+	
+	// model with filename that alphabetically precedes model-settings.json
+
+	{
+		ModelID:   "model-filename-precedes-model-settings",
+		ModelType: "sklearn",
+		ModelPath: "data",
+		InputFiles: []string{
+			"data/model-settings.json",
+			"data/aaaaa.json",
+		},
+		InputConfig: map[string]interface{}{
+			"name":           "model-name",
+			"implementation": "mlserver_sklearn.SKLearnModel",
+			"parameters": map[string]interface{}{
+				"uri":     "./aaaaa.json",
+			},
+		},
+		ExpectedFiles: []string{
+			"model-settings.json",
+			"aaaaa.json",
+		},
+		ExpectedConfig: map[string]interface{}{
+			"name":           "model-filename-precedes-model-settings",
+			"implementation": "mlserver_sklearn.SKLearnModel",
+			"parameters": map[string]interface{}{
+				"uri":     filepath.Join(generatedMlserverModelsDir, "model-filename-precedes-model-settings", "aaaaa.json"),
+			},
+		},
 	},
 }
 

--- a/model-mesh-mlserver-adapter/server/server.go
+++ b/model-mesh-mlserver-adapter/server/server.go
@@ -190,11 +190,17 @@ func adaptModelLayoutForRuntime(rootModelDir, modelID, modelType, modelPath, sch
 		// check if the config file exists
 		// if it does, we assume files are in the "native" repo structure
 		assumeNativeLayout := false
-		for _, f := range files {
+		configFileIndex := -1
+		for i, f := range files {
 			if f.Name() == mlserverRepositoryConfigFilename {
 				assumeNativeLayout = true
+				configFileIndex = i
 				break
 			}
+		}
+		// always process the config file first to ensure that uri conversion within config file is correct
+		if configFileIndex > 0 {
+			files[0], files[configFileIndex] = files[configFileIndex], files[0]
 		}
 		if assumeNativeLayout {
 			err = adaptNativeModelLayout(files, modelID, modelPath, schemaPath, mlserverModelIDDir, log)


### PR DESCRIPTION
#### Motivation

As documented in [this issue](https://github.com/kserve/modelmesh-runtime-adapter/issues/40), there is currently a bug in the conversion of the `uri` provided in the MLServer `model-settings.json` file if the model files are symlinked before the uri conversion occurs. This PR is intended to fix the issue by ensuring that `model-settings.json` will always be processed first.

#### Modifications

The function `adaptModelLayoutForRuntime` in the MLServer adapter `server.go` was modified to ensure that, if present, the `model-settings.json` file will be placed at the head of the list of files to be processed. This makes sure that the config file will always be processed before any symlinks are created for the model files.

A unit test was also added to ensure that the bug was fixed.

#### Result

Incorrect uri conversion bug no longer occurs even when the model files alphabetically precede the filename`model-settings.json`.
