### PR TITLE
Restore SecureJoin logic to puller

### DIFF
--- a/model-serving-puller/puller/puller.go
+++ b/model-serving-puller/puller/puller.go
@@ -185,11 +185,11 @@ func (s *Puller) ProcessLoadModelRequest(ctx context.Context, req *mmesh.LoadMod
 
 	// update model path to an absolute path in the local filesystem
 	// commment out SecureJoin since it doesn't handle symlinks well
-	// modelFullPath, joinErr := util.SecureJoin(modelDir, modelPathFilename)
-	// if joinErr != nil {
-	// 	return nil, fmt.Errorf("Error joining paths '%s' and '%s': %w", modelDir, modelPathFilename, joinErr)
-	// }
-	modelFullPath := modelDir + string(filepath.Separator) + modelPathFilename
+	modelFullPath, joinErr := util.SecureJoin(modelDir, modelPathFilename)
+	if joinErr != nil {
+		return nil, fmt.Errorf("Error joining paths '%s' and '%s': %w", modelDir, modelPathFilename, joinErr)
+	}
+	//modelFullPath := modelDir + string(filepath.Separator) + modelPathFilename
 
 	req.ModelPath = modelFullPath
 


### PR DESCRIPTION
@ckadner 

#### Motivation
Replacing the SecureJoin from the Puller broke the loading of HTTP models, see the [corresponding issue](https://github.com/kserve/modelmesh-runtime-adapter/issues/41).

#### Modifications
Reverted [the removal of the SecureJoin](https://github.com/kserve/modelmesh-runtime-adapter/commit/69920979f7181d13bf1e61a588cea6ff1e6270b2#diff-d2a332b0b59e3a7eb5342fbac94a7579fb5141229326af37664a3b20c1308fa1L186) from merge #36:

From Merge 36:
```go
modelFullPath := modelDir + string(filepath.Separator) + modelPathFilename
```

New:
Original and Restored:
```go
modelFullPath, joinErr := util.SecureJoin(modelDir, modelPathFilename)
if joinErr != nil {
	return nil, fmt.Errorf("Error joining paths '%s' and '%s': %w", modelDir, modelPathFilename, joinErr)
}
```

#### Result
HTTP models load as expected; tested via a direct comparison of building the current `main` image versus the image built from this PR in a deployment of opendatahub, using an HTTP model inference service. The `main` image displayed the same error raised in [this issue](https://github.com/kserve/modelmesh-runtime-adapter/issues/41), the one built from this PR worked fine.

#### Note
This returns the puller to its pre-merge 46 state, however, that PR did mention that the SecureJoin does not handle symlinks well; this PR does not address that concern. 