### PR TITLE
fix: build all binaries for the target OS/ARCH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,8 +116,8 @@ ARG TARGETARCH
 # https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    GOOS=${TARGETOS:-linux} \
-    GOARCH=${TARGETARCH:-amd64} \
+    export GOOS=${TARGETOS:-linux} && \
+    export GOARCH=${TARGETARCH:-amd64} && \
     go build -o puller model-serving-puller/main.go && \
     go build -o triton-adapter model-mesh-triton-adapter/main.go && \
     go build -o mlserver-adapter model-mesh-mlserver-adapter/main.go && \


### PR DESCRIPTION
#### Motivation

Fix the multi-arch builds so that all binaries are built for the target OS/ARCH. Currently, only the `puller` is built for the target.

#### Modifications

- export GOOS and GOARCH within multi-command RUN that builds the binaries

#### Result
