### PR TITLE
chore: Add new approvers to OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,8 @@
 approvers:
   - njhill
   - tjohnson31415
+  - ckadner
+  - rafvasq
 reviewers:
   - njhill
   - tjohnson31415


### PR DESCRIPTION
Add new approvers to OWNERS file following KServe community process.

Closes kserve/community#6

/assign @njhill @tjohnson31415 