### PR TITLE
chore: Upgrade Golang version from 1.17 to 1.19

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@
 .DS_Store
 Dockerfile
 temp
+.pre-commit.log
+

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 *.iml
 
 public/
+
+.pre-commit.log
+

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -93,16 +93,13 @@ linters:
   fast: false
   enable:
     # These are the defaults for golangci-lint
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
 
     # Also enable these
     - goconst

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.43.0
+    rev: v1.51.1
     hooks:
       - id: golangci-lint
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,9 @@ repos:
     rev: v1.51.1
     hooks:
       - id: golangci-lint
+        log_file: /tmp/pre-commit.log
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.4.1
     hooks:
       - id: prettier
+        log_file: /tmp/pre-commit.log

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,9 +16,9 @@ repos:
     rev: v1.51.1
     hooks:
       - id: golangci-lint
-        log_file: /tmp/pre-commit.log
+        log_file: .pre-commit.log
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.4.1
     hooks:
       - id: prettier
-        log_file: /tmp/pre-commit.log
+        log_file: .pre-commit.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 ###############################################################################
 # Stage 1: Create the developer image for the BUILDPLATFORM only
 ###############################################################################
-ARG GOLANG_VERSION=1.17
+ARG GOLANG_VERSION=1.19
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION AS develop
 
 ARG PROTOC_VERSION=21.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,8 @@ RUN true \
 COPY .pre-commit-config.yaml ./
 RUN git init && \
     pre-commit install-hooks && \
+    # Fix: 'fatal: detected dubious ownership in repository' \
+    git config --global --add safe.directory "*" && \
     rm -rf .git
 
 # Download dependencies before copying the source so they will be cached

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ run: use.develop
 
 .PHONY: test
 ## Run tests
-test:
+test: fmt
 	./scripts/run_tests.sh
 
 .PHONY: fmt

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ run: use.develop
 
 .PHONY: test
 ## Run tests
-test: fmt
+test:
 	./scripts/run_tests.sh
 
 .PHONY: fmt

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kserve/modelmesh-runtime-adapter
 
-go 1.17
+go 1.19
 
 require (
 	cloud.google.com/go/storage v1.28.1
@@ -12,7 +12,7 @@ require (
 	github.com/go-logr/zapr v1.2.3
 	github.com/golang/mock v1.6.0
 	github.com/joho/godotenv v1.4.0
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.23.0
 	golang.org/x/sync v0.1.0
 	google.golang.org/api v0.114.0

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,9 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -21,7 +21,7 @@ import (
 	"github.com/go-logr/logr"
 )
 
-// GetEnvString Returns the string value of environment variable "key" or the default value
+// Returns the string value of environment variable "key" or the default value
 // if "key" is not set. Note if the environment variable is set to an empty
 // string, this will return an empty string, not defaultValue.
 func GetEnvString(key string, defaultValue string) string {
@@ -31,7 +31,7 @@ func GetEnvString(key string, defaultValue string) string {
 	return defaultValue
 }
 
-// GetEnvInt Returns the integer of value environment variable "key" or the default value
+// Returns the integer of value environment variable "key" or the default value
 // if "key" is not set. Note if the environment variable is set to a non
 // integer, including an empty string, this will fail and exit.
 func GetEnvInt(key string, defaultValue int, log logr.Logger) int {
@@ -70,7 +70,7 @@ func GetEnvFloat(key string, defaultValue float64, log logr.Logger) float64 {
 	return defaultValue
 }
 
-// GetEnvBool Returns the bool value of environment variable "key" or the default value
+// Returns the bool value of environment variable "key" or the default value
 // if "key" is not set. Note if the environment variable is set to a non
 // boolean, including an empty string, this will fail and exit.
 func GetEnvBool(key string, defaultValue bool, log logr.Logger) bool {
@@ -85,7 +85,7 @@ func GetEnvBool(key string, defaultValue bool, log logr.Logger) bool {
 	return defaultValue
 }
 
-// GetEnvDuration Returns the duration value of environment variable "key" or a default value
+// Returns the duration value of environment variable "key" or a default value
 // Note if the environment variable cannot be parsed as a duration, including an
 // empty string, this will fail and exit.
 func GetEnvDuration(key string, defaultValue time.Duration, log logr.Logger) time.Duration {

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package envconfig
 
 import (

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package envconfig
 
 import (

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -21,7 +21,7 @@ import (
 	"github.com/go-logr/logr"
 )
 
-// Returns the string value of environment variable "key" or the default value
+// GetEnvString Returns the string value of environment variable "key" or the default value
 // if "key" is not set. Note if the environment variable is set to an empty
 // string, this will return an empty string, not defaultValue.
 func GetEnvString(key string, defaultValue string) string {
@@ -31,7 +31,7 @@ func GetEnvString(key string, defaultValue string) string {
 	return defaultValue
 }
 
-// Returns the integer of value environment variable "key" or the default value
+// GetEnvInt Returns the integer of value environment variable "key" or the default value
 // if "key" is not set. Note if the environment variable is set to a non
 // integer, including an empty string, this will fail and exit.
 func GetEnvInt(key string, defaultValue int, log logr.Logger) int {
@@ -70,7 +70,7 @@ func GetEnvFloat(key string, defaultValue float64, log logr.Logger) float64 {
 	return defaultValue
 }
 
-// Returns the bool value of environment variable "key" or the default value
+// GetEnvBool Returns the bool value of environment variable "key" or the default value
 // if "key" is not set. Note if the environment variable is set to a non
 // boolean, including an empty string, this will fail and exit.
 func GetEnvBool(key string, defaultValue bool, log logr.Logger) bool {
@@ -85,7 +85,7 @@ func GetEnvBool(key string, defaultValue bool, log logr.Logger) bool {
 	return defaultValue
 }
 
-// Returns the duration value of environment variable "key" or a default value
+// GetEnvDuration Returns the duration value of environment variable "key" or a default value
 // Note if the environment variable cannot be parsed as a duration, including an
 // empty string, this will fail and exit.
 func GetEnvDuration(key string, defaultValue time.Duration, log logr.Logger) time.Duration {

--- a/internal/modelschema/modelschema.go
+++ b/internal/modelschema/modelschema.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ package modelschema
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // Filename for the schema JSON
@@ -55,7 +55,7 @@ const (
 )
 
 func NewFromFile(schemaFilename string) (*ModelSchema, error) {
-	jsonBytes, err := ioutil.ReadFile(schemaFilename)
+	jsonBytes, err := os.ReadFile(schemaFilename)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to read model schema file %s: %w", schemaFilename, err)
 	}

--- a/internal/modelschema/modelschema.go
+++ b/internal/modelschema/modelschema.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package modelschema
 
 import (

--- a/internal/modelschema/modelschema.go
+++ b/internal/modelschema/modelschema.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package modelschema
 
 import (

--- a/internal/util/connect.go
+++ b/internal/util/connect.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/util/connect.go
+++ b/internal/util/connect.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package util
 
 import (

--- a/internal/util/connect.go
+++ b/internal/util/connect.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package util
 
 import (

--- a/internal/util/connect_test.go
+++ b/internal/util/connect_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/util/connect_test.go
+++ b/internal/util/connect_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package util
 
 import (

--- a/internal/util/connect_test.go
+++ b/internal/util/connect_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package util
 
 import (

--- a/internal/util/fileutil.go
+++ b/internal/util/fileutil.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+// 	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/util/fileutil.go
+++ b/internal/util/fileutil.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package util
 
 import (
@@ -22,7 +23,7 @@ import (
 
 // RemoveFileFromListOfFileInfo
 // The input `files` content is modified, the order of elements is changed
-func RemoveFileFromListOfFileInfo(filename string, files []os.FileInfo) (bool, []os.FileInfo) {
+func RemoveFileFromListOfFileInfo(filename string, files []os.DirEntry) (bool, []os.DirEntry) {
 	var fileIndex int = -1
 	for i, f := range files {
 		if f.Name() == filename {
@@ -38,7 +39,7 @@ func RemoveFileFromListOfFileInfo(filename string, files []os.FileInfo) (bool, [
 	return true, files[:len(files)-1]
 }
 
-// Check if a file exists at path
+// FileExists Check if a file exists at path
 func FileExists(path string) (bool, error) {
 	if _, err := os.Stat(path); err == nil {
 		return true, nil
@@ -49,7 +50,7 @@ func FileExists(path string) (bool, error) {
 	}
 }
 
-// Clear contents of directory if it exists.
+// ClearDirectoryContents Clear contents of directory if it exists.
 // If condition is specified then only delete dir entries to which it returns true
 func ClearDirectoryContents(dirPath string, condition func(entry os.DirEntry) bool) error {
 	files, err := os.ReadDir(dirPath)

--- a/internal/util/fileutil.go
+++ b/internal/util/fileutil.go
@@ -39,7 +39,7 @@ func RemoveFileFromListOfFileInfo(filename string, files []os.DirEntry) (bool, [
 	return true, files[:len(files)-1]
 }
 
-// FileExists Check if a file exists at path
+// Check if a file exists at path
 func FileExists(path string) (bool, error) {
 	if _, err := os.Stat(path); err == nil {
 		return true, nil

--- a/internal/util/fileutil.go
+++ b/internal/util/fileutil.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// 	http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package util
 
 import (

--- a/internal/util/join.go
+++ b/internal/util/join.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/util/join.go
+++ b/internal/util/join.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package util
 
 import (

--- a/internal/util/join.go
+++ b/internal/util/join.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package util
 
 import (

--- a/internal/util/join_test.go
+++ b/internal/util/join_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/util/join_test.go
+++ b/internal/util/join_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package util
 
 import (

--- a/internal/util/join_test.go
+++ b/internal/util/join_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package util
 
 import (

--- a/internal/util/loadmodel.go
+++ b/internal/util/loadmodel.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/util/loadmodel.go
+++ b/internal/util/loadmodel.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package util
 
 import (

--- a/internal/util/loadmodel.go
+++ b/internal/util/loadmodel.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package util
 
 import (

--- a/model-mesh-mlserver-adapter/main.go
+++ b/model-mesh-mlserver-adapter/main.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-mlserver-adapter/main.go
+++ b/model-mesh-mlserver-adapter/main.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package main
 
 import (

--- a/model-mesh-mlserver-adapter/main.go
+++ b/model-mesh-mlserver-adapter/main.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (

--- a/model-mesh-mlserver-adapter/mlserver/mock_mlserver_server.go
+++ b/model-mesh-mlserver-adapter/mlserver/mock_mlserver_server.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package main
 
 import (

--- a/model-mesh-mlserver-adapter/mlserver/mock_mlserver_server.go
+++ b/model-mesh-mlserver-adapter/mlserver/mock_mlserver_server.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (

--- a/model-mesh-mlserver-adapter/server/adaptmodellayout_test.go
+++ b/model-mesh-mlserver-adapter/server/adaptmodellayout_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,6 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -98,7 +97,7 @@ func (tt adaptModelLayoutTestCase) writeConfigFile(t *testing.T) {
 	if jerr != nil {
 		t.Fatal("Error marshalling config JSON", jerr)
 	}
-	if err := ioutil.WriteFile(configFullPath, jsonBytes, 0644); err != nil {
+	if err := os.WriteFile(configFullPath, jsonBytes, 0644); err != nil {
 		t.Fatalf("Unable to write config JSON: %v", err)
 	}
 }
@@ -110,7 +109,7 @@ func (tt adaptModelLayoutTestCase) writeSchemaFile(t *testing.T) {
 	}
 
 	schemaFullPath := filepath.Join(tt.getSourceDir(), tt.SchemaPath)
-	if werr := ioutil.WriteFile(schemaFullPath, jsonBytes, 0644); werr != nil {
+	if werr := os.WriteFile(schemaFullPath, jsonBytes, 0644); werr != nil {
 		t.Fatal("Error writing JSON to schema file", werr)
 	}
 }
@@ -533,7 +532,7 @@ func TestAdaptModelLayoutForRuntime(t *testing.T) {
 			}
 
 			// read in the config to assert on it
-			configJSON, err2 := ioutil.ReadFile(configFilePath)
+			configJSON, err2 := os.ReadFile(configFilePath)
 			if err2 != nil {
 				t.Fatalf("Unable to read config file %s: %v", configFilePath, err2)
 			}
@@ -635,7 +634,7 @@ func assertCreateEmptyFile(path string, t *testing.T) {
 
 func createFile(path, contents string) error {
 	os.MkdirAll(filepath.Dir(path), 0755)
-	err := ioutil.WriteFile(path, []byte(contents), 0644)
+	err := os.WriteFile(path, []byte(contents), 0644)
 	return err
 }
 

--- a/model-mesh-mlserver-adapter/server/adaptmodellayout_test.go
+++ b/model-mesh-mlserver-adapter/server/adaptmodellayout_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-mlserver-adapter/server/adaptmodellayout_test.go
+++ b/model-mesh-mlserver-adapter/server/adaptmodellayout_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-mesh-mlserver-adapter/server/config.go
+++ b/model-mesh-mlserver-adapter/server/config.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-mlserver-adapter/server/config.go
+++ b/model-mesh-mlserver-adapter/server/config.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-mlserver-adapter/server/config.go
+++ b/model-mesh-mlserver-adapter/server/config.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-mesh-mlserver-adapter/server/server.go
+++ b/model-mesh-mlserver-adapter/server/server.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-mlserver-adapter/server/server.go
+++ b/model-mesh-mlserver-adapter/server/server.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-mesh-mlserver-adapter/server/server_test.go
+++ b/model-mesh-mlserver-adapter/server/server_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -215,7 +214,7 @@ func TestProcessConfigJSON(t *testing.T) {
 }
 
 func assertGeneratedModelDirIsCorrect(sourceDir string, generatedDir string, modelID string, t *testing.T) {
-	generatedFiles, err := ioutil.ReadDir(generatedDir)
+	generatedFiles, err := os.ReadDir(generatedDir)
 	if err != nil {
 		t.Errorf("Could not read files in generated dir [%s]: %v", generatedDir, err)
 	}
@@ -227,7 +226,7 @@ func assertGeneratedModelDirIsCorrect(sourceDir string, generatedDir string, mod
 		if f.Name() == mlserverRepositoryConfigFilename {
 			configFileFound = true
 			// should have `name` field matching the modelID
-			configJSON, err := ioutil.ReadFile(filePath)
+			configJSON, err := os.ReadFile(filePath)
 			if err != nil {
 				t.Errorf("Unable to read config file %s: %v", filePath, err)
 			}
@@ -245,7 +244,7 @@ func assertGeneratedModelDirIsCorrect(sourceDir string, generatedDir string, mod
 
 		// if not the config file, it should be a symlink pointing to a file in the
 		// source dir that exists
-		if f.Mode()&os.ModeSymlink != os.ModeSymlink {
+		if f.Type()&os.ModeSymlink != os.ModeSymlink {
 			t.Errorf("Expected [%s] to be a symlink.", filePath)
 		}
 

--- a/model-mesh-mlserver-adapter/server/server_test.go
+++ b/model-mesh-mlserver-adapter/server/server_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-mlserver-adapter/server/server_test.go
+++ b/model-mesh-mlserver-adapter/server/server_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-mesh-ovms-adapter/main.go
+++ b/model-mesh-ovms-adapter/main.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-ovms-adapter/main.go
+++ b/model-mesh-ovms-adapter/main.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package main
 
 import (

--- a/model-mesh-ovms-adapter/main.go
+++ b/model-mesh-ovms-adapter/main.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (

--- a/model-mesh-ovms-adapter/server/adaptmodellayout.go
+++ b/model-mesh-ovms-adapter/server/adaptmodellayout.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -53,7 +52,7 @@ func adaptModelLayoutForRuntime(ctx context.Context, rootModelDir, modelID, mode
 		// simple case if ModelPath points to a file
 		err = createOvmsModelRepositoryFromPath(modelPath, "1", schemaPath, modelType, ovmsModelIDDir, log)
 	} else {
-		files, err1 := ioutil.ReadDir(modelPath)
+		files, err1 := os.ReadDir(modelPath)
 		if err1 != nil {
 			return fmt.Errorf("Could not read files in dir %s: %w", modelPath, err1)
 		}
@@ -68,7 +67,7 @@ func adaptModelLayoutForRuntime(ctx context.Context, rootModelDir, modelID, mode
 
 // Creates the ovms model structure /models/_ovms_models/model-id/1/<model files>
 // Within this path there will be a symlink back to the original /models/model-id directory tree.
-func createOvmsModelRepositoryFromDirectory(files []os.FileInfo, modelPath, schemaPath, modelType, ovmsModelIDDir string, log logr.Logger) error {
+func createOvmsModelRepositoryFromDirectory(files []os.DirEntry, modelPath, schemaPath, modelType, ovmsModelIDDir string, log logr.Logger) error {
 	var err error
 
 	// allow the directory to contain version directories
@@ -126,8 +125,8 @@ func createOvmsModelRepositoryFromPath(modelPath, versionNumber, schemaPath, mod
 }
 
 // Returns the largest positive int dir as long as all fileInfo dirs are integers (files are ignored).
-// If fileInfos is empty or contains any any non-integer dirs, this will return the empty string.
-func largestNumberDir(fileInfos []os.FileInfo) string {
+// If fileInfos is empty or contains any non-integer dirs, this will return the empty string.
+func largestNumberDir(fileInfos []os.DirEntry) string {
 	largestInt := 0
 	largestDir := ""
 	for _, f := range fileInfos {

--- a/model-mesh-ovms-adapter/server/adaptmodellayout.go
+++ b/model-mesh-ovms-adapter/server/adaptmodellayout.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-ovms-adapter/server/adaptmodellayout.go
+++ b/model-mesh-ovms-adapter/server/adaptmodellayout.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-mesh-ovms-adapter/server/adaptmodellayout_test.go
+++ b/model-mesh-ovms-adapter/server/adaptmodellayout_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -82,7 +81,7 @@ func (tt adaptModelLayoutTestCase) writeSchemaFile(t *testing.T) {
 	}
 
 	schemaFullpath := filepath.Join(tt.getSourceDir(), tt.SchemaPath)
-	if werr := ioutil.WriteFile(schemaFullpath, jsonBytes, 0644); werr != nil {
+	if werr := os.WriteFile(schemaFullpath, jsonBytes, 0644); werr != nil {
 		t.Fatal("Error writing JSON to schema file", werr)
 	}
 }
@@ -253,9 +252,7 @@ func findSymlinks(root string) []string {
 	return result
 }
 
-//
 // Definition of writeModelLayoutForRuntime test cases
-//
 var adaptModelLayoutTests = []adaptModelLayoutTestCase{
 	// Group: ONNX format
 	{

--- a/model-mesh-ovms-adapter/server/adaptmodellayout_test.go
+++ b/model-mesh-ovms-adapter/server/adaptmodellayout_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-ovms-adapter/server/adaptmodellayout_test.go
+++ b/model-mesh-ovms-adapter/server/adaptmodellayout_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-mesh-ovms-adapter/server/config.go
+++ b/model-mesh-ovms-adapter/server/config.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-ovms-adapter/server/config.go
+++ b/model-mesh-ovms-adapter/server/config.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-ovms-adapter/server/config.go
+++ b/model-mesh-ovms-adapter/server/config.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-mesh-ovms-adapter/server/const.go
+++ b/model-mesh-ovms-adapter/server/const.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-ovms-adapter/server/const.go
+++ b/model-mesh-ovms-adapter/server/const.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 const (

--- a/model-mesh-ovms-adapter/server/const.go
+++ b/model-mesh-ovms-adapter/server/const.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 const (

--- a/model-mesh-ovms-adapter/server/modelconfig.go
+++ b/model-mesh-ovms-adapter/server/modelconfig.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,22 +19,23 @@ package server
 // JSON Schema: https://github.com/openvinotoolkit/model_server/blob/eab97207fbe9078f83a3f85b468418555b02959a/src/schema.cpp#L28
 //
 // EXAMPLE:
-// {
-//   "model_config_list": [
-//     {
-//       "config": {
-//         "name": "model_name1",
-//         "base_path": "/models/model1"
-//       }
-//     },
-//     {
-//       "config": {
-//         "name": "model_name2",
-//         "base_path": "/models/model1"
-//       }
-//     }
-//   ]
-// }
+//
+//	{
+//	  "model_config_list": [
+//	    {
+//	      "config": {
+//	        "name": "model_name1",
+//	        "base_path": "/models/model1"
+//	      }
+//	    },
+//	    {
+//	      "config": {
+//	        "name": "model_name2",
+//	        "base_path": "/models/model1"
+//	      }
+//	    }
+//	  ]
+//	}
 type OvmsMultiModelRepositoryConfig struct {
 	ModelConfigList []OvmsMultiModelConfigListEntry `json:"model_config_list"`
 }

--- a/model-mesh-ovms-adapter/server/modelconfig.go
+++ b/model-mesh-ovms-adapter/server/modelconfig.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 // Types defining the structure of the OVMS Multi-Model config file

--- a/model-mesh-ovms-adapter/server/modelconfig.go
+++ b/model-mesh-ovms-adapter/server/modelconfig.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 // Types defining the structure of the OVMS Multi-Model config file

--- a/model-mesh-ovms-adapter/server/modelmanager.go
+++ b/model-mesh-ovms-adapter/server/modelmanager.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-ovms-adapter/server/modelmanager.go
+++ b/model-mesh-ovms-adapter/server/modelmanager.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-ovms-adapter/server/modelmanager.go
+++ b/model-mesh-ovms-adapter/server/modelmanager.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (
@@ -20,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -261,7 +261,7 @@ type request struct {
 
 // Run loop for the manager's internal actor that owns the model repository config
 //
-// Maintains a slice of batched requests that are in process in the reload
+// # Maintains a slice of batched requests that are in process in the reload
 //
 // Returns results from the reload operation once it completes
 // Receives a stream of requests from its channel
@@ -342,7 +342,6 @@ func (mm *OvmsModelManager) run() {
 // This handles deciding which requests will require a reload, completing
 // requests that will not change the state and ignoring requests that are
 // cancelled.
-//
 //
 // We need a criteria to determine when to stop grabbing requests after a reload
 // is needed; here we take the approach of waiting for a period of time after a
@@ -512,7 +511,7 @@ func (mm *OvmsModelManager) writeConfig() error {
 		return fmt.Errorf("Error marshalling config file: %w", err)
 	}
 
-	if err := ioutil.WriteFile(mm.modelConfigFilename, modelRepositoryConfigJSON, mm.config.ModelConfigFilePerms); err != nil {
+	if err := os.WriteFile(mm.modelConfigFilename, modelRepositoryConfigJSON, mm.config.ModelConfigFilePerms); err != nil {
 		return fmt.Errorf("Error writing config file: %w", err)
 	}
 

--- a/model-mesh-ovms-adapter/server/modelmanager.go
+++ b/model-mesh-ovms-adapter/server/modelmanager.go
@@ -259,9 +259,8 @@ type request struct {
 	c   chan<- error
 }
 
-// Run loop for the manager's internal actor that owns the model repository config
-//
-// # Maintains a slice of batched requests that are in process in the reload
+// run loop for the manager's internal actor that owns the model repository config
+// Maintains a slice of batched requests that are in process in the reload
 //
 // Returns results from the reload operation once it completes
 // Receives a stream of requests from its channel

--- a/model-mesh-ovms-adapter/server/modelmanager_test.go
+++ b/model-mesh-ovms-adapter/server/modelmanager_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-ovms-adapter/server/modelmanager_test.go
+++ b/model-mesh-ovms-adapter/server/modelmanager_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-ovms-adapter/server/modelmanager_test.go
+++ b/model-mesh-ovms-adapter/server/modelmanager_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-mesh-ovms-adapter/server/server.go
+++ b/model-mesh-ovms-adapter/server/server.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-ovms-adapter/server/server.go
+++ b/model-mesh-ovms-adapter/server/server.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-ovms-adapter/server/server.go
+++ b/model-mesh-ovms-adapter/server/server.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-mesh-ovms-adapter/server/server_test.go
+++ b/model-mesh-ovms-adapter/server/server_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -255,7 +254,7 @@ func TestAdapter(t *testing.T) {
 }
 
 func checkEntryExistsInModelConfig(modelid string, path string) error {
-	configBytes, err := ioutil.ReadFile(testModelConfigFile)
+	configBytes, err := os.ReadFile(testModelConfigFile)
 	if err != nil {
 		return fmt.Errorf("Unable to read config file: %w", err)
 	}

--- a/model-mesh-ovms-adapter/server/server_test.go
+++ b/model-mesh-ovms-adapter/server/server_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-ovms-adapter/server/server_test.go
+++ b/model-mesh-ovms-adapter/server/server_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-mesh-torchserve-adapter/main.go
+++ b/model-mesh-torchserve-adapter/main.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-torchserve-adapter/main.go
+++ b/model-mesh-torchserve-adapter/main.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package main
 
 import (

--- a/model-mesh-torchserve-adapter/main.go
+++ b/model-mesh-torchserve-adapter/main.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (

--- a/model-mesh-torchserve-adapter/server/config.go
+++ b/model-mesh-torchserve-adapter/server/config.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-torchserve-adapter/server/config.go
+++ b/model-mesh-torchserve-adapter/server/config.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-mesh-torchserve-adapter/server/server.go
+++ b/model-mesh-torchserve-adapter/server/server.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-torchserve-adapter/server/server_test.go
+++ b/model-mesh-torchserve-adapter/server/server_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-torchserve-adapter/torchserve/mock_torchserve_server.go
+++ b/model-mesh-torchserve-adapter/torchserve/mock_torchserve_server.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package main
 
 import (

--- a/model-mesh-torchserve-adapter/torchserve/mock_torchserve_server.go
+++ b/model-mesh-torchserve-adapter/torchserve/mock_torchserve_server.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -105,10 +105,10 @@ func serve(server *grpc.Server, port uint16, log logr.Logger) {
 
 // Implements gomock TestReporter interface:
 //
-// type TestReporter interface {
-// 	Errorf(format string, args ...interface{})
-// 	Fatalf(format string, args ...interface{})
-// }
+//	type TestReporter interface {
+//		Errorf(format string, args ...interface{})
+//		Fatalf(format string, args ...interface{})
+//	}
 type CustomReporter struct {
 	log logr.Logger
 }

--- a/model-mesh-torchserve-adapter/torchserve/mock_torchserve_server.go
+++ b/model-mesh-torchserve-adapter/torchserve/mock_torchserve_server.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (

--- a/model-mesh-triton-adapter/main.go
+++ b/model-mesh-triton-adapter/main.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-triton-adapter/main.go
+++ b/model-mesh-triton-adapter/main.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package main
 
 import (

--- a/model-mesh-triton-adapter/main.go
+++ b/model-mesh-triton-adapter/main.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (

--- a/model-mesh-triton-adapter/server/adaptmodellayout.go
+++ b/model-mesh-triton-adapter/server/adaptmodellayout.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-triton-adapter/server/adaptmodellayout.go
+++ b/model-mesh-triton-adapter/server/adaptmodellayout.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-triton-adapter/server/adaptmodellayout.go
+++ b/model-mesh-triton-adapter/server/adaptmodellayout.go
@@ -4,20 +4,20 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -100,7 +100,7 @@ func adaptModelLayoutForRuntime(ctx context.Context, rootModelDir, modelID, mode
 		// simple case if ModelPath points to a file
 		err = createTritonModelRepositoryFromPath(modelPath, "1", schemaPath, modelType, tritonModelIDDir, log)
 	} else {
-		files, err1 := ioutil.ReadDir(modelPath)
+		files, err1 := os.ReadDir(modelPath)
 		if err1 != nil {
 			return fmt.Errorf("Could not read files in dir %s: %w", modelPath, err1)
 		}
@@ -121,7 +121,7 @@ func adaptModelLayoutForRuntime(ctx context.Context, rootModelDir, modelID, mode
 // Creates the triton model structure /models/_triton_models/model-id/1/model.X where
 // model.X is a file or directory with a name defined by the model type (see modelTypeToDirNameMapping and modelTypeToFileNameMapping).
 // Within this path there will be a symlink back to the original /models/model-id directory tree.
-func createTritonModelRepositoryFromDirectory(files []os.FileInfo, modelPath, schemaPath, modelType, tritonModelIDDir string, log logr.Logger) error {
+func createTritonModelRepositoryFromDirectory(files []os.DirEntry, modelPath, schemaPath, modelType, tritonModelIDDir string, log logr.Logger) error {
 	var err error
 
 	// for backwards compatibility, remove any file called _schema.json from
@@ -138,7 +138,7 @@ func createTritonModelRepositoryFromDirectory(files []os.FileInfo, modelPath, sc
 			return err
 		}
 
-		if files, err = ioutil.ReadDir(modelPath); err != nil {
+		if files, err = os.ReadDir(modelPath); err != nil {
 			return fmt.Errorf("Could not read files in dir %s: %w", modelPath, err)
 		}
 	} else {
@@ -233,7 +233,7 @@ func createTritonModelRepositoryFromPath(modelPath, versionNumber, schemaPath, m
 // If the Triton specific config file exists, assume the model files has the
 // proper structure, but process the config.pbtxt to remove the `name` field.
 // All other files are symlinked to their source
-func adaptNativeModelLayout(files []os.FileInfo, sourceModelIDDir, schemaPath, tritonModelIDDir string, log logr.Logger) error {
+func adaptNativeModelLayout(files []os.DirEntry, sourceModelIDDir, schemaPath, tritonModelIDDir string, log logr.Logger) error {
 	for _, f := range files {
 		var err1 error
 		filename := f.Name()
@@ -245,7 +245,7 @@ func adaptNativeModelLayout(files []os.FileInfo, sourceModelIDDir, schemaPath, t
 
 		// special handling of the config file
 		if filename == tritonRepositoryConfigFilename {
-			pbtxt, err2 := ioutil.ReadFile(source)
+			pbtxt, err2 := os.ReadFile(source)
 			if err2 != nil {
 				return fmt.Errorf("Error reading config file %s: %w", source, err2)
 			}
@@ -261,7 +261,8 @@ func adaptNativeModelLayout(files []os.FileInfo, sourceModelIDDir, schemaPath, t
 				return err2
 			}
 
-			if err2 = ioutil.WriteFile(target, processedPbtxt, f.Mode()); err2 != nil {
+			info, _ := f.Info()
+			if err2 = os.WriteFile(target, processedPbtxt, info.Mode()); err2 != nil {
 				return fmt.Errorf("Error writing config file %s: %w", source, err2)
 			}
 
@@ -283,8 +284,8 @@ func adaptNativeModelLayout(files []os.FileInfo, sourceModelIDDir, schemaPath, t
 }
 
 // Returns the largest positive int dir as long as all fileInfo dirs are integers (files are ignored).
-// If fileInfos is empty or contains any any non-integer dirs, this will return the empty string.
-func largestNumberDir(fileInfos []os.FileInfo) string {
+// If fileInfos is empty or contains any non-integer dirs, this will return the empty string.
+func largestNumberDir(fileInfos []os.DirEntry) string {
 	largestInt := 0
 	largestDir := ""
 	for _, f := range fileInfos {
@@ -307,8 +308,8 @@ func largestNumberDir(fileInfos []os.FileInfo) string {
 // Returns true if these the files make up the top level of a triton model repository.
 // In other words, the parent of the files is the root of the triton repository (we don't pass the parent path
 // because then we'd have to read the filesystem more than once).
-// Currently this is using the existence of file 'config.pbtxt' to determine it is a triton repository.
-func isTritonModelRepository(files []os.FileInfo) bool {
+// Currently, this is using the existence of file 'config.pbtxt' to determine it is a triton repository.
+func isTritonModelRepository(files []os.DirEntry) bool {
 	for _, f := range files {
 		if f.Name() == tritonRepositoryConfigFilename {
 			return true

--- a/model-mesh-triton-adapter/server/adaptmodellayout_test.go
+++ b/model-mesh-triton-adapter/server/adaptmodellayout_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -172,7 +171,7 @@ func (tt adaptModelLayoutTestCase) writeSchemaFile(t *testing.T) {
 	}
 
 	schemaFullpath := filepath.Join(tt.getSourceDir(), tt.SchemaPath)
-	if werr := ioutil.WriteFile(schemaFullpath, jsonBytes, 0644); werr != nil {
+	if werr := os.WriteFile(schemaFullpath, jsonBytes, 0644); werr != nil {
 		t.Fatal("Error writing JSON to schema file", werr)
 	}
 }
@@ -278,7 +277,7 @@ func assertConfigFileContents(t *testing.T, tt adaptModelLayoutTestCase) {
 
 	// read in the generated config file
 	configFilePath := filepath.Join(tt.getTargetDir(), "config.pbtxt")
-	configFileContents, err := ioutil.ReadFile(configFilePath)
+	configFileContents, err := os.ReadFile(configFilePath)
 	if err != nil {
 		t.Fatalf("Unable to read config file [%s]: %v", configFilePath, err)
 	}
@@ -379,9 +378,7 @@ func findSymlinks(root string) []string {
 	return result
 }
 
-//
 // Definition of writeModelLayoutForRuntime test cases
-//
 var adaptModelLayoutTests = []adaptModelLayoutTestCase{
 	// Group: file layout / model path support
 	{

--- a/model-mesh-triton-adapter/server/adaptmodellayout_test.go
+++ b/model-mesh-triton-adapter/server/adaptmodellayout_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-triton-adapter/server/adaptmodellayout_test.go
+++ b/model-mesh-triton-adapter/server/adaptmodellayout_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-mesh-triton-adapter/server/config.go
+++ b/model-mesh-triton-adapter/server/config.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-triton-adapter/server/config.go
+++ b/model-mesh-triton-adapter/server/config.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-triton-adapter/server/config.go
+++ b/model-mesh-triton-adapter/server/config.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-mesh-triton-adapter/server/const.go
+++ b/model-mesh-triton-adapter/server/const.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-triton-adapter/server/const.go
+++ b/model-mesh-triton-adapter/server/const.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 const (

--- a/model-mesh-triton-adapter/server/const.go
+++ b/model-mesh-triton-adapter/server/const.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 const (

--- a/model-mesh-triton-adapter/server/schema.go
+++ b/model-mesh-triton-adapter/server/schema.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-triton-adapter/server/schema.go
+++ b/model-mesh-triton-adapter/server/schema.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 // Refer to this proto file for schema and supported data types

--- a/model-mesh-triton-adapter/server/schema.go
+++ b/model-mesh-triton-adapter/server/schema.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 // Refer to this proto file for schema and supported data types

--- a/model-mesh-triton-adapter/server/schema_test.go
+++ b/model-mesh-triton-adapter/server/schema_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-triton-adapter/server/schema_test.go
+++ b/model-mesh-triton-adapter/server/schema_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-triton-adapter/server/schema_test.go
+++ b/model-mesh-triton-adapter/server/schema_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-mesh-triton-adapter/server/server.go
+++ b/model-mesh-triton-adapter/server/server.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-triton-adapter/server/server.go
+++ b/model-mesh-triton-adapter/server/server.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-triton-adapter/server/server.go
+++ b/model-mesh-triton-adapter/server/server.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-mesh-triton-adapter/server/server_test.go
+++ b/model-mesh-triton-adapter/server/server_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -156,7 +155,7 @@ func TestAdapter(t *testing.T) {
 	// Check that the `name` property was removed from the config file
 	{
 		var err1 error
-		pbtxt, err1 := ioutil.ReadFile(configFile)
+		pbtxt, err1 := os.ReadFile(configFile)
 		if err1 != nil {
 			t.Errorf("Unable to read config file %s: %v", configFile, err)
 		}

--- a/model-mesh-triton-adapter/server/server_test.go
+++ b/model-mesh-triton-adapter/server/server_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-triton-adapter/server/server_test.go
+++ b/model-mesh-triton-adapter/server/server_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-mesh-triton-adapter/server/utils.go
+++ b/model-mesh-triton-adapter/server/utils.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-triton-adapter/server/utils.go
+++ b/model-mesh-triton-adapter/server/utils.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-mesh-triton-adapter/server/utils.go
+++ b/model-mesh-triton-adapter/server/utils.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (
@@ -18,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -55,7 +55,7 @@ func writeConfigPbtxt(filename string, modelConfig *triton.ModelConfig) error {
 		return fmt.Errorf("Unable to marshal config.pbtxt: %w", err)
 	}
 
-	if err = ioutil.WriteFile(filename, pbtxtOut, 0644); err != nil {
+	if err = os.WriteFile(filename, pbtxtOut, 0644); err != nil {
 		return fmt.Errorf("Unable to write config.pbtxt: %w", err)
 	}
 	return nil

--- a/model-mesh-triton-adapter/triton/adapter_client/adapter_client.go
+++ b/model-mesh-triton-adapter/triton/adapter_client/adapter_client.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-triton-adapter/triton/adapter_client/adapter_client.go
+++ b/model-mesh-triton-adapter/triton/adapter_client/adapter_client.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package main
 
 import (

--- a/model-mesh-triton-adapter/triton/adapter_client/adapter_client.go
+++ b/model-mesh-triton-adapter/triton/adapter_client/adapter_client.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (

--- a/model-mesh-triton-adapter/triton/mesh_client/mesh_client.go
+++ b/model-mesh-triton-adapter/triton/mesh_client/mesh_client.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-triton-adapter/triton/mesh_client/mesh_client.go
+++ b/model-mesh-triton-adapter/triton/mesh_client/mesh_client.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package main
 
 import (

--- a/model-mesh-triton-adapter/triton/mesh_client/mesh_client.go
+++ b/model-mesh-triton-adapter/triton/mesh_client/mesh_client.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (

--- a/model-mesh-triton-adapter/triton/mock_triton_server.go
+++ b/model-mesh-triton-adapter/triton/mock_triton_server.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-mesh-triton-adapter/triton/mock_triton_server.go
+++ b/model-mesh-triton-adapter/triton/mock_triton_server.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package main
 
 import (

--- a/model-mesh-triton-adapter/triton/mock_triton_server.go
+++ b/model-mesh-triton-adapter/triton/mock_triton_server.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (

--- a/model-serving-puller/main.go
+++ b/model-serving-puller/main.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-serving-puller/main.go
+++ b/model-serving-puller/main.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package main
 
 import (

--- a/model-serving-puller/main.go
+++ b/model-serving-puller/main.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (

--- a/model-serving-puller/puller/config.go
+++ b/model-serving-puller/puller/config.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,13 +16,13 @@ package puller
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/go-logr/logr"
 
-	. "github.com/kserve/modelmesh-runtime-adapter/internal/envconfig"
 	"github.com/kserve/modelmesh-runtime-adapter/internal/util"
+
+	. "github.com/kserve/modelmesh-runtime-adapter/internal/envconfig"
 )
 
 // PullerConfiguration stores configuration variables for the puller server
@@ -72,7 +72,7 @@ func (config *PullerConfiguration) GetStorageConfiguration(storageKey string, lo
 		return nil, fmt.Errorf("Storage secretKey not found: %s", storageKey)
 	}
 
-	bytes, err := ioutil.ReadFile(configPath)
+	bytes, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("Could not read storage configuration from %s: %v", configPath, err)
 	}

--- a/model-serving-puller/puller/config.go
+++ b/model-serving-puller/puller/config.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package puller
 
 import (

--- a/model-serving-puller/puller/config.go
+++ b/model-serving-puller/puller/config.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package puller
 
 import (

--- a/model-serving-puller/puller/dotpath.go
+++ b/model-serving-puller/puller/dotpath.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-serving-puller/puller/dotpath.go
+++ b/model-serving-puller/puller/dotpath.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package puller
 
 import (

--- a/model-serving-puller/puller/dotpath.go
+++ b/model-serving-puller/puller/dotpath.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package puller
 
 import (

--- a/model-serving-puller/puller/dotpath_test.go
+++ b/model-serving-puller/puller/dotpath_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-serving-puller/puller/dotpath_test.go
+++ b/model-serving-puller/puller/dotpath_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package puller
 
 import (

--- a/model-serving-puller/puller/dotpath_test.go
+++ b/model-serving-puller/puller/dotpath_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package puller
 
 import (

--- a/model-serving-puller/puller/puller.go
+++ b/model-serving-puller/puller/puller.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -58,7 +57,8 @@ type Puller struct {
 }
 
 // PullerInterface is the interface for `pullman`
-//  useful to mock for testing
+//
+//	useful to mock for testing
 type PullerInterface interface {
 	Pull(context.Context, pullman.PullCommand) error
 }
@@ -291,7 +291,7 @@ func (p *Puller) ClearLocalModelStorage(exclude string) error {
 }
 
 func (p *Puller) ListModels() ([]string, error) {
-	entries, err := ioutil.ReadDir(p.PullerConfig.RootModelDir)
+	entries, err := os.ReadDir(p.PullerConfig.RootModelDir)
 	if err != nil {
 		return nil, err
 	}

--- a/model-serving-puller/puller/puller.go
+++ b/model-serving-puller/puller/puller.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package puller
 
 import (

--- a/model-serving-puller/puller/puller.go
+++ b/model-serving-puller/puller/puller.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package puller
 
 import (

--- a/model-serving-puller/puller/puller_test.go
+++ b/model-serving-puller/puller/puller_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -99,7 +98,7 @@ func eqPullCommand(pc *pullman.PullCommand) gomock.Matcher {
 // helper to create a RepositoryConfig from the testdata storage config dir
 func readStorageConfig(key string) (*pullman.RepositoryConfig, error) {
 
-	j, err := ioutil.ReadFile(filepath.Join(StorageConfigDir, key))
+	j, err := os.ReadFile(filepath.Join(StorageConfigDir, key))
 	if err != nil {
 		return nil, err
 	}
@@ -428,7 +427,7 @@ func Test_ProcessLoadModelRequest_SuccessStorageTypeOnly(t *testing.T) {
 func Test_ProcessLoadModelRequest_DefaultStorageKey(t *testing.T) {
 	// create a typeless default storage config file for this test
 	defaultConfigFile := filepath.Join(StorageConfigDir, "default")
-	err := ioutil.WriteFile(defaultConfigFile, []byte(`{"type": "typeless-default"}`), 0555)
+	err := os.WriteFile(defaultConfigFile, []byte(`{"type": "typeless-default"}`), 0555)
 	assert.NoError(t, err)
 	defer func() {
 		errd := os.Remove(defaultConfigFile)

--- a/model-serving-puller/puller/puller_test.go
+++ b/model-serving-puller/puller/puller_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package puller
 
 import (

--- a/model-serving-puller/puller/puller_test.go
+++ b/model-serving-puller/puller/puller_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package puller
 
 import (

--- a/model-serving-puller/server/config.go
+++ b/model-serving-puller/server/config.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-serving-puller/server/config.go
+++ b/model-serving-puller/server/config.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-serving-puller/server/config.go
+++ b/model-serving-puller/server/config.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-serving-puller/server/modelstate.go
+++ b/model-serving-puller/server/modelstate.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-serving-puller/server/modelstate.go
+++ b/model-serving-puller/server/modelstate.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-serving-puller/server/modelstate.go
+++ b/model-serving-puller/server/modelstate.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-serving-puller/server/modelstate_test.go
+++ b/model-serving-puller/server/modelstate_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-serving-puller/server/modelstate_test.go
+++ b/model-serving-puller/server/modelstate_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-serving-puller/server/modelstate_test.go
+++ b/model-serving-puller/server/modelstate_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-serving-puller/server/server.go
+++ b/model-serving-puller/server/server.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-serving-puller/server/server.go
+++ b/model-serving-puller/server/server.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package server
 
 import (

--- a/model-serving-puller/server/server.go
+++ b/model-serving-puller/server/server.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/model-serving-puller/server/server_test.go
+++ b/model-serving-puller/server/server_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/model-serving-puller/server/server_test.go
+++ b/model-serving-puller/server/server_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package server
 
 import (

--- a/pullman/cache.go
+++ b/pullman/cache.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/cache.go
+++ b/pullman/cache.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package pullman
 
 import (

--- a/pullman/cache.go
+++ b/pullman/cache.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package pullman
 
 import (

--- a/pullman/cache_test.go
+++ b/pullman/cache_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/cache_test.go
+++ b/pullman/cache_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package pullman
 
 import (

--- a/pullman/cache_test.go
+++ b/pullman/cache_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package pullman
 
 import (

--- a/pullman/cmd/main.go
+++ b/pullman/cmd/main.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package main
 
 import (

--- a/pullman/cmd/main.go
+++ b/pullman/cmd/main.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
@@ -65,7 +65,7 @@ func main() {
 	manager := pullman.NewPullManager(zapr.NewLogger(zaplog))
 
 	// create repository from the config file
-	configMapJSON, err := ioutil.ReadFile(configFilename)
+	configMapJSON, err := os.ReadFile(configFilename)
 	if err != nil {
 		fmt.Printf("Error reading config file [%s]: %v\n", configFilename, err)
 		return

--- a/pullman/cmd/main.go
+++ b/pullman/cmd/main.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (

--- a/pullman/config.go
+++ b/pullman/config.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/config.go
+++ b/pullman/config.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package pullman
 
 import (

--- a/pullman/config.go
+++ b/pullman/config.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package pullman
 
 import (

--- a/pullman/config_test.go
+++ b/pullman/config_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/config_test.go
+++ b/pullman/config_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package pullman
 
 import (

--- a/pullman/config_test.go
+++ b/pullman/config_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package pullman
 
 import (

--- a/pullman/helpers.go
+++ b/pullman/helpers.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/helpers.go
+++ b/pullman/helpers.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package pullman
 
 import (

--- a/pullman/helpers.go
+++ b/pullman/helpers.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package pullman
 
 import (

--- a/pullman/pullman.go
+++ b/pullman/pullman.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/pullman.go
+++ b/pullman/pullman.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package pullman
 
 import (

--- a/pullman/pullman.go
+++ b/pullman/pullman.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package pullman
 
 import (

--- a/pullman/pullman_test.go
+++ b/pullman/pullman_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/pullman_test.go
+++ b/pullman/pullman_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package pullman
 
 import (

--- a/pullman/pullman_test.go
+++ b/pullman/pullman_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package pullman
 
 import (

--- a/pullman/storageproviders/azure/downloader.go
+++ b/pullman/storageproviders/azure/downloader.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/storageproviders/azure/downloader.go
+++ b/pullman/storageproviders/azure/downloader.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package azureprovider
 
 import (

--- a/pullman/storageproviders/azure/downloader.go
+++ b/pullman/storageproviders/azure/downloader.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package azureprovider
 
 import (

--- a/pullman/storageproviders/azure/provider.go
+++ b/pullman/storageproviders/azure/provider.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/storageproviders/azure/provider.go
+++ b/pullman/storageproviders/azure/provider.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package azureprovider
 
 import (

--- a/pullman/storageproviders/azure/provider.go
+++ b/pullman/storageproviders/azure/provider.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package azureprovider
 
 import (

--- a/pullman/storageproviders/azure/provider_test.go
+++ b/pullman/storageproviders/azure/provider_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/storageproviders/azure/provider_test.go
+++ b/pullman/storageproviders/azure/provider_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package azureprovider
 
 import (

--- a/pullman/storageproviders/azure/provider_test.go
+++ b/pullman/storageproviders/azure/provider_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package azureprovider
 
 import (

--- a/pullman/storageproviders/gcs/downloader.go
+++ b/pullman/storageproviders/gcs/downloader.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/storageproviders/gcs/downloader.go
+++ b/pullman/storageproviders/gcs/downloader.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package gcsprovider
 
 import (

--- a/pullman/storageproviders/gcs/downloader.go
+++ b/pullman/storageproviders/gcs/downloader.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package gcsprovider
 
 import (

--- a/pullman/storageproviders/gcs/provider.go
+++ b/pullman/storageproviders/gcs/provider.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/storageproviders/gcs/provider.go
+++ b/pullman/storageproviders/gcs/provider.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package gcsprovider
 
 import (

--- a/pullman/storageproviders/gcs/provider.go
+++ b/pullman/storageproviders/gcs/provider.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package gcsprovider
 
 import (

--- a/pullman/storageproviders/gcs/provider_test.go
+++ b/pullman/storageproviders/gcs/provider_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/storageproviders/gcs/provider_test.go
+++ b/pullman/storageproviders/gcs/provider_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package gcsprovider
 
 import (

--- a/pullman/storageproviders/gcs/provider_test.go
+++ b/pullman/storageproviders/gcs/provider_test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package gcsprovider
 
 import (

--- a/pullman/storageproviders/http/downloader.go
+++ b/pullman/storageproviders/http/downloader.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/storageproviders/http/downloader.go
+++ b/pullman/storageproviders/http/downloader.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package httpprovider
 
 import (

--- a/pullman/storageproviders/http/downloader.go
+++ b/pullman/storageproviders/http/downloader.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package httpprovider
 
 import (

--- a/pullman/storageproviders/http/provider.go
+++ b/pullman/storageproviders/http/provider.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/storageproviders/http/provider.go
+++ b/pullman/storageproviders/http/provider.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package httpprovider
 
 import (

--- a/pullman/storageproviders/http/provider_test.go
+++ b/pullman/storageproviders/http/provider_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/storageproviders/http/provider_test.go
+++ b/pullman/storageproviders/http/provider_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package httpprovider
 
 import (

--- a/pullman/storageproviders/pvc/provider.go
+++ b/pullman/storageproviders/pvc/provider.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/storageproviders/pvc/provider.go
+++ b/pullman/storageproviders/pvc/provider.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package pvcprovider
 
 import (

--- a/pullman/storageproviders/pvc/provider_test.go
+++ b/pullman/storageproviders/pvc/provider_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/storageproviders/pvc/provider_test.go
+++ b/pullman/storageproviders/pvc/provider_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package pvcprovider
 
 import (

--- a/pullman/storageproviders/s3/downloader.go
+++ b/pullman/storageproviders/s3/downloader.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/storageproviders/s3/downloader.go
+++ b/pullman/storageproviders/s3/downloader.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package s3provider
 
 import (

--- a/pullman/storageproviders/s3/downloader_test.go
+++ b/pullman/storageproviders/s3/downloader_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/storageproviders/s3/downloader_test.go
+++ b/pullman/storageproviders/s3/downloader_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package s3provider
 
 import (

--- a/pullman/storageproviders/s3/provider.go
+++ b/pullman/storageproviders/s3/provider.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/storageproviders/s3/provider.go
+++ b/pullman/storageproviders/s3/provider.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package s3provider
 
 import (

--- a/pullman/storageproviders/s3/provider_test.go
+++ b/pullman/storageproviders/s3/provider_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/storageproviders/s3/provider_test.go
+++ b/pullman/storageproviders/s3/provider_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package s3provider
 
 import (

--- a/pullman/types.go
+++ b/pullman/types.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pullman/types.go
+++ b/pullman/types.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package pullman
 
 import (

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -16,9 +16,9 @@
 pre-commit run --all-files
 RETURN_CODE=$?
 
-## cat this file for helping on identifying the root cause when some issue happens
-if [ -f /$USER/.cache/pre-commit/pre-commit.log ]; then
-  cat /$USER/.cache/pre-commit/pre-commit.log
+# cat this file for helping on identifying the root cause when some issue happens
+if [ -f /tmp/pre-commit.log ]; then
+  cat /tmp/pre-commit.log
 fi
 
 function echoError() {

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -11,7 +11,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.#
+# limitations under the License.
 
 pre-commit run --all-files
 RETURN_CODE=$?

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -13,12 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.#
 
-# Fix: 'fatal: detected dubious ownership in repository',
-# only do this if it is running into the develop image
-if [ "${PWD}" == "/opt/app" ]; then
-  git config --global --add safe.directory "*"
-fi
-
 pre-commit run --all-files
 RETURN_CODE=$?
 

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -17,8 +17,8 @@ pre-commit run --all-files
 RETURN_CODE=$?
 
 # cat this file for helping on identifying the root cause when some issue happens
-if [ -f /tmp/pre-commit.log ]; then
-  cat /tmp/pre-commit.log
+if [ -f .pre-commit.log ]; then
+  cat .pre-commit.log
 fi
 
 function echoError() {

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -13,8 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.#
 
+# Fix: 'fatal: detected dubious ownership in repository',
+# only do this if it is running into the develop image
+if [ "${PWD}" == "/opt/app" ]; then
+  git config --global --add safe.directory "*"
+fi
+
 pre-commit run --all-files
 RETURN_CODE=$?
+
+## cat this file for helping on identifying the root cause when some issue happens
+if [ -f /$USER/.cache/pre-commit/pre-commit.log ]; then
+  cat /$USER/.cache/pre-commit/pre-commit.log
+fi
 
 function echoError() {
   LIGHT_YELLOW='\033[1;33m'


### PR DESCRIPTION
chore: Go lang 1.17 is a little bit old and 1.19 as well. However, before taking a greater step to higher version would might be better to break it in smaller changes since the amount of changes that this update has required is a little bit high, here is a small description of what was changed by this update:

- Outdated linters:
  - WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
  - WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
  - WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.

- Deprecation of the io/ioutils package:
  - SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package [io] or package [os] - Used the `os` package and the needed code changes applied

- At puller/config.go
  - ( undefined: GetEnvString)
  - Fixed by `import . "github.com/kserve/modelmesh-runtime-adapter/internal/envconfig"`

- Some comments and headers adjusted
- small identation changes made as part of go fmt.

Fixes https://github.com/kserve/modelmesh-runtime-adapter/issues/64