### PR TITLE
fix: Incorrect conversion between integer types

### DIFF
--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,6 +42,17 @@ func GetEnvInt(key string, defaultValue int, log logr.Logger) int {
 			os.Exit(1)
 		}
 		return val
+	}
+	return defaultValue
+}
+
+func GetEnvInt32(key string, defaultValue int32, log logr.Logger) int32 {
+	if strVal, found := os.LookupEnv(key); found {
+		if valueInt, err := strconv.ParseInt(strVal, 10, 32); err != nil {
+			log.Error(err, "Environment variable must be an int32", "env_var", key, "value", strVal)
+		} else {
+			return int32(valueInt)
+		}
 	}
 	return defaultValue
 }

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -52,9 +52,8 @@ func GetEnvInt32(key string, defaultValue int32, log logr.Logger) int32 {
 		if err != nil {
 			log.Error(err, "Environment variable must be of type int32", "env_var", key, "value", strVal)
 			os.Exit(1)
-		} else {
-			return int32(val)
 		}
+		return int32(val)
 	}
 	return defaultValue
 }

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -48,10 +48,12 @@ func GetEnvInt(key string, defaultValue int, log logr.Logger) int {
 
 func GetEnvInt32(key string, defaultValue int32, log logr.Logger) int32 {
 	if strVal, found := os.LookupEnv(key); found {
-		if valueInt, err := strconv.ParseInt(strVal, 10, 32); err != nil {
-			log.Error(err, "Environment variable must be an int32", "env_var", key, "value", strVal)
+		val, err := strconv.ParseInt(strVal, 10, 32)
+		if err != nil {
+			log.Error(err, "Environment variable must be of type int32", "env_var", key, "value", strVal)
+			os.Exit(1)
 		} else {
-			return int32(valueInt)
+			return int32(val)
 		}
 	}
 	return defaultValue

--- a/model-mesh-torchserve-adapter/server/config.go
+++ b/model-mesh-torchserve-adapter/server/config.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -81,8 +81,8 @@ func GetAdapterConfigurationFromEnv(log logr.Logger) (*AdapterConfiguration, err
 		return nil, fmt.Errorf("Could not construct torchserve model store path: %w", err)
 	}
 
-	adapterConfig.RequestBatchSize = int32(GetEnvInt(requestBatchSize, defaultRequestBatchSize, log))
-	adapterConfig.MaxBatchDelaySecs = int32(GetEnvInt(maxBatchDelaySecs, defaultMaxBatchDelaySecs, log))
+	adapterConfig.RequestBatchSize = GetEnvInt32(requestBatchSize, defaultRequestBatchSize, log)
+	adapterConfig.MaxBatchDelaySecs = GetEnvInt32(maxBatchDelaySecs, defaultMaxBatchDelaySecs, log)
 
 	if adapterConfig.TorchServeContainerMemReqBytes < 0 {
 		return nil, fmt.Errorf("%s environment variable must be set to a positive integer, found value %v",


### PR DESCRIPTION
Created function `GetEnvInt32` using `strconv.ParseInt` as recommended for accuracy in cases where `int32` is expected. Similar to [modelmesh-serving's #446](https://github.com/kserve/modelmesh-serving/pull/446)

- https://github.com/kserve/modelmesh-runtime-adapter/security/code-scanning/1
- https://github.com/kserve/modelmesh-runtime-adapter/security/code-scanning/2