### PR TITLE
Update Go Lang and base iamges

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.51.1
+    rev: v1.60.3
     hooks:
       - id: golangci-lint
         log_file: .pre-commit.log

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kserve/modelmesh-runtime-adapter
 
-go 1.21
+go 1.22.9
 
 require (
 	cloud.google.com/go/storage v1.28.1


### PR DESCRIPTION
chore:	Update Go lang from 1.21 to 1.22.9
	Update golint-ci to 1.60.3 to be compatible with go1.22
	Update base images from UBI8 to UBI9

#### Motivation

#### Modifications

#### Result
